### PR TITLE
Switch to debian:wheezy and add GCE debian mirror

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
-FROM debian:jessie
+FROM debian:wheezy
 ENV DEBIAN_FRONTEND noninteractive
+RUN sed -i '1i deb     http://gce_debian_mirror.storage.googleapis.com/ wheezy         main' /etc/apt/sources.list
 RUN apt-get update && apt-get install -y -qq --no-install-recommends wget unzip python php5-mysql php5-cli php5-cgi openjdk-7-jre-headless openssh-client && apt-get clean
 RUN wget https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.zip && unzip google-cloud-sdk.zip && rm google-cloud-sdk.zip
 RUN google-cloud-sdk/install.sh --usage-reporting=true --path-update=true --bash-completion=true --rc-path=/.bashrc --disable-installation-options


### PR DESCRIPTION
This switches the base of the google/cloud-sdk image to wheezy, so that we can use the Google Compute Engine debian mirrors to more efficiently install packages.
