### PR TITLE
Updated to Cloud SDK v0.9.30

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,13 @@ Compute Engine:
     $ docker run -t -i --volumes-from gcloud-config google/cloud-sdk gcloud version
 
 If you are using this image from *within* Google Compute Engine with an enabled
-Service Account, there is no need to auth or use a config volume:
+Service Account and your instance was created with the necessary scopes, there
+is no need to auth or use a config volume:
 
     # get the cloud sdk image
     $ docker pull google/cloud-sdk
 
-    # re-use the credentials from gcloud-config volumes & run sdk commands
+    # just start using the sdk commands
     $ docker run -t -i google/cloud-sdk gcutil listinstances
     $ docker run -t -i google/cloud-sdk gsutil ls
     $ docker run -t -i google/cloud-sdk gcloud components list


### PR DESCRIPTION
Merging will re-generate the google/cloud-sdk docker image.

This update includes the latest Cloud SDK v0.9.30 and its sub-commands.  Minor update to the instructions based on if the user is running this image from outside of Compute Engine or within it.

@brendandburns - mind kicking the tires before I merge since @proppy is out-of-pocket?
