### PR TITLE
Fixed to a place expecting a config directory.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN sed -i '1i deb     http://gce_debian_mirror.storage.googleapis.com/ wheezy         main' /etc/apt/sources.list
 RUN apt-get update && apt-get install -y -qq --no-install-recommends wget unzip python php5-mysql php5-cli php5-cgi openjdk-7-jre-headless openssh-client && apt-get clean
 RUN wget https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.zip && unzip google-cloud-sdk.zip && rm google-cloud-sdk.zip
+ENV HOME /
 RUN google-cloud-sdk/install.sh --usage-reporting=true --path-update=true --bash-completion=true --rc-path=/.bashrc --disable-installation-options
 RUN yes | google-cloud-sdk/bin/gcloud components update pkg-go pkg-python pkg-java
 RUN mkdir /.ssh


### PR DESCRIPTION
Actually, the config of gcloud was made at "/root/.config", even it should be made at "/.config"  written by README [docker-registry](https://github.com/GoogleCloudPlatform/docker-registry). So i fixed it to be made at "/.config"
