### PR TITLE
turn off update nags

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ RUN apt-get update && apt-get install -y -qq --no-install-recommends wget unzip 
 RUN wget https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.zip && unzip google-cloud-sdk.zip && rm google-cloud-sdk.zip
 ENV CLOUDSDK_PYTHON_SITEPACKAGES 1
 RUN google-cloud-sdk/install.sh --usage-reporting=true --path-update=true --bash-completion=true --rc-path=/.bashrc --disable-installation-options
-RUN yes | google-cloud-sdk/bin/gcloud components update pkg-go pkg-python pkg-java preview app
+RUN google-cloud-sdk/bin/gcloud --quiet components update pkg-go pkg-python pkg-java preview app
+RUN google-cloud-sdk/bin/gcloud --quiet config set component_manager/disable_update_check true
 RUN mkdir /.ssh
 ENV PATH /google-cloud-sdk/bin:$PATH
 ENV HOME /


### PR DESCRIPTION
The update nag suggests people run an ineffective (because it runs in the short-lived container's filesystem) update command. Let's just turn it off and let people re-pull the image when they want an update.