### PR TITLE
fix on version 0.9.65 to get gae-python, gae-php, and gae-go components

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && apt-get install -y -qq --no-install-recommends wget unzip python php5-mysql php5-cli php5-cgi openjdk-7-jre-headless openssh-client python-openssl && apt-get clean
 RUN wget https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.zip && unzip google-cloud-sdk.zip && rm google-cloud-sdk.zip
 ENV CLOUDSDK_PYTHON_SITEPACKAGES 1
+ENV CLOUDSDK_COMPONENT_MANAGER_FIXED_SDK_VERSION 0.9.67
 RUN google-cloud-sdk/install.sh --usage-reporting=true --path-update=true --bash-completion=true --rc-path=/.bashrc --disable-installation-options
 RUN google-cloud-sdk/bin/gcloud --quiet components update pkg-go pkg-python pkg-java preview alpha beta app
 RUN google-cloud-sdk/bin/gcloud --quiet config set component_manager/disable_update_check true

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && apt-get install -y -qq --no-install-recommends wget unzip python php5-mysql php5-cli php5-cgi openjdk-7-jre-headless openssh-client python-openssl && apt-get clean
 RUN wget https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.zip && unzip google-cloud-sdk.zip && rm google-cloud-sdk.zip
 ENV CLOUDSDK_PYTHON_SITEPACKAGES 1
-ENV CLOUDSDK_COMPONENT_MANAGER_FIXED_SDK_VERSION 0.9.67
+ENV CLOUDSDK_COMPONENT_MANAGER_FIXED_SDK_VERSION 0.9.65
 RUN google-cloud-sdk/install.sh --usage-reporting=true --path-update=true --bash-completion=true --rc-path=/.bashrc --disable-installation-options
 RUN google-cloud-sdk/bin/gcloud --quiet components update pkg-go pkg-python pkg-java preview alpha beta app
 RUN google-cloud-sdk/bin/gcloud --quiet config set component_manager/disable_update_check true


### PR DESCRIPTION
Hello there !

goapp wasn't found any more, because it was removed from gcloud version 0.9.68

I am sure other people rely on this behaviour so I'm adding this.

Until someone does a container for each gae tool...

Cheers !

PS: you should tag this into a branch 0.9.65 for example

Edit: I tried 0.9.67 in vain …