### PR TITLE
Update the gcloud installation dockerfile to play nice in a container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,25 @@
-FROM google/debian:wheezy
+FROM gcr.io/google_appengine/base
+
+# Prepare the image.
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && apt-get install -y -qq --no-install-recommends wget unzip python php5-mysql php5-cli php5-cgi openjdk-7-jre-headless openssh-client python-openssl && apt-get clean
-RUN wget https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.zip && unzip google-cloud-sdk.zip && rm google-cloud-sdk.zip
+
+# Install the Google Cloud SDK.
+ENV HOME /
 ENV CLOUDSDK_PYTHON_SITEPACKAGES 1
-RUN google-cloud-sdk/install.sh --usage-reporting=true --path-update=true --bash-completion=true --rc-path=/.bashrc --disable-installation-options
-RUN google-cloud-sdk/bin/gcloud --quiet components update pkg-go pkg-python pkg-java preview alpha beta app
-RUN google-cloud-sdk/bin/gcloud --quiet config set component_manager/disable_update_check true
+RUN wget https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.zip && unzip google-cloud-sdk.zip && rm google-cloud-sdk.zip
+RUN google-cloud-sdk/install.sh --usage-reporting=true --path-update=true --bash-completion=true --rc-path=/.bashrc --additional-components app alpha beta
+
+# Disable updater check for the whole installation.
+# Users won't be bugged with notifications to update to the latest version of gcloud.
+RUN google-cloud-sdk/bin/gcloud config set --installation component_manager/disable_update_check true
+
+# Disable updater completely.
+# Running `gcloud components update` doesn't really do anything in a union FS.
+# Changes are lost on a subsequent run.
+RUN sed -i -- 's/\"disable_updater\": false/\"disable_updater\": true/g' /google-cloud-sdk/lib/googlecloudsdk/core/config.json
+
 RUN mkdir /.ssh
 ENV PATH /google-cloud-sdk/bin:$PATH
-ENV HOME /
 VOLUME ["/.config"]
 CMD ["/bin/bash"]

--- a/test.sh
+++ b/test.sh
@@ -12,6 +12,7 @@ cleanup() {
 trap 'cleanup' 0
 docker build -t ${GCLOUD_SDK} .
 docker rm ${GCLOUD_CONFIG} || true
+docker run --rm ${GCLOUD_SDK} gcloud info
 docker run --rm ${GCLOUD_SDK} gcloud components list | grep 'Not Installed' && false
 docker run -ti --name ${GCLOUD_CONFIG} ${GCLOUD_SDK} gcloud auth login
 docker run --rm --volumes-from ${GCLOUD_CONFIG} ${GCLOUD_SDK} gcutil --project ${PROJECT} listinstances


### PR DESCRIPTION
- update base image
- disable components updater -- any components update changes will be
  lost anyway
- disable update check -- updates don't persist anyway
- update the URL with the changed new download location
- change the HOME dir at the start so any subsequent run commands that
  change stuff in ~/.config are written to /.config and are actually
  visible.