### PR TITLE
Support for GCE and updated README for how to use Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,5 +21,5 @@ RUN sed -i -- 's/\"disable_updater\": false/\"disable_updater\": true/g' /google
 
 RUN mkdir /.ssh
 ENV PATH /google-cloud-sdk/bin:$PATH
-VOLUME ["/.config"]
+VOLUME ["/.config", "/.kube"]
 CMD ["/bin/bash"]

--- a/README.md
+++ b/README.md
@@ -22,6 +22,17 @@ Follow these instructions if you are running docker *outside* of Google Compute 
     $ docker run --rm -ti --volumes-from gcloud-config google/cloud-sdk gcutil listinstances
     $ docker run --rm -ti --volumes-from gcloud-config google/cloud-sdk gsutil ls
 
+    #
+    # To use Google Container Environment (GCE)
+    #
+
+    # Save credentials in gcloud-config volume
+    $ docker run -t -i --name gcloud-config google/cloud-sdk gcloud container clusters get-credentials <cluster-name>
+    
+    # Re-use the credentials from gcloud-config volumes & run kubectl commands:
+    $ docker run -t -i --name gcloud-config google/cloud-sdk kubectl cluster-info
+
+    
 If you are using this image from *within* [Google Compute Engine](https://cloud.google.com/compute/). If you enable a Service Account with the necessary scopes, there is no need to auth or use a config volume:
 
     # Get the cloud sdk image:

--- a/README.md
+++ b/README.md
@@ -32,6 +32,17 @@ Follow these instructions if you are running docker *outside* of Google Compute 
     # Re-use the credentials from gcloud-config volumes & run kubectl commands:
     $ docker run -t -i --name gcloud-config google/cloud-sdk kubectl cluster-info
 
+    #
+    # To use Google Container Registry (GCR) with docker from host
+    #
+    
+    # Get an auth token
+    $ docker run --rm -ti --volumes-from gcloud-config google/cloud-sdk gcloud auth print-access-token
+    # Login to docker
+    $ docker login -e not@val.id -u _token -p <token> https://gcr.io
+
+    # Use docker as usual...
+    $ docker pull gcr.io/<project>/<repo>
     
 If you are using this image from *within* [Google Compute Engine](https://cloud.google.com/compute/). If you enable a Service Account with the necessary scopes, there is no need to auth or use a config volume:
 


### PR DESCRIPTION
kubectl tools included in Google-SDK uses .kube directory as default for it's configuration, so currently all changes made with kubectl config set <option> is lost.

Also fetching configuration with gcloud container clusters get-credentials <cluster> has the same issue.

Until this fix is merged, the config storage container can be created manually instead of using google/cloud-sdk as described in the readme:

```
docker run -it --name gcloud-config -v /.config -v /.kube busybox true
docker run -it --rm --volumes-from gcloud-config google/cloud-sdk gcloud init
docker run -it --rm --volumes-from gcloud-config google/cloud-sdk gcloud container clusters get-credentials <cluster>
docker run -it --rm --volumes-from gcloud-config google/cloud-sdk kubectl cluster-info

```