### PR TITLE
Include git in the installed packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM gcr.io/google_appengine/base
 
 # Prepare the image.
 ENV DEBIAN_FRONTEND noninteractive
-RUN apt-get update && apt-get install -y -qq --no-install-recommends wget unzip python php5-mysql php5-cli php5-cgi openjdk-7-jre-headless openssh-client python-openssl && apt-get clean
+RUN apt-get update && apt-get install -y -qq --no-install-recommends wget unzip python php5-mysql php5-cli php5-cgi openjdk-7-jre-headless openssh-client python-openssl git && apt-get clean
 
 # Install the Google Cloud SDK.
 ENV HOME /


### PR DESCRIPTION
I ran gcloud init and it complained as indicated below.  After apt-get install git, it's able to clone the repo without error:

Where would you like to clone [default] repository to [/default]:/default/repo
ERROR: (gcloud.source.repos.clone) Cannot find git. Please install git and try again.

You can find git installers at [http://git-scm.com/downloads], or use
your favorite package manager to install it on your computer. Make sure
it can be found on your system PATH.
WARNING: Was not able to run
  [gcloud source repos clone default /default/repo]
at this time. You can try running this command any time later.
