### PR TITLE
Added Cloud Datastore Emulator & Cloud Pub/Sub Emulator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@ RUN apt-get update && apt-get install -y -qq --no-install-recommends wget unzip 
 ENV HOME /
 ENV CLOUDSDK_PYTHON_SITEPACKAGES 1
 RUN wget https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.zip && unzip google-cloud-sdk.zip && rm google-cloud-sdk.zip
-RUN google-cloud-sdk/install.sh --usage-reporting=true --path-update=true --bash-completion=true --rc-path=/.bashrc --additional-components app-engine-java app-engine-python app kubectl alpha beta
+RUN google-cloud-sdk/install.sh --usage-reporting=true --path-update=true --bash-completion=true --rc-path=/.bashrc --additional-components app-engine-java app-engine-python app kubectl alpha beta gcd-emulator pubsub-emulator
+
 
 # Disable updater check for the whole installation.
 # Users won't be bugged with notifications to update to the latest version of gcloud.
@@ -18,6 +19,7 @@ RUN google-cloud-sdk/bin/gcloud config set --installation component_manager/disa
 # Running `gcloud components update` doesn't really do anything in a union FS.
 # Changes are lost on a subsequent run.
 RUN sed -i -- 's/\"disable_updater\": false/\"disable_updater\": true/g' /google-cloud-sdk/lib/googlecloudsdk/core/config.json
+
 
 RUN mkdir /.ssh
 ENV PATH /google-cloud-sdk/bin:$PATH


### PR DESCRIPTION
Added new SDK components:
- Cloud Datastore Emulator
- Cloud Pub/Sub Emulator

These additional components are useful when running Google Cloud Datastore and Pub/Sub in a flexible environment (without Google AppEngine).