### PR TITLE
Update base image to Debian; all components

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,20 @@
-FROM alpine:3.5
-ARG CLOUD_SDK_VERSION=159.0.0
-ARG SHA256SUM=5b408575407514f99ad913bd0c6991be4b46408ddc7080a6494bbf43e6ce222a
-ENV PATH /google-cloud-sdk/bin:$PATH
-RUN apk --no-cache add curl python py-crcmod bash libc6-compat && \
-    curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz && \
-    echo "${SHA256SUM}  google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz" > google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz.sha256 && \
-    sha256sum -c google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz.sha256 && \
-    tar xzf google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz && \
-    rm google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz.sha256 && \
-    ln -s /lib /lib64 && \
+FROM debian:jessie
+RUN apt-get update && apt-get install -qqy curl gcc python-dev python-setuptools apt-transport-https lsb-release openssh-client && \
+    easy_install -U pip && \
+    pip install -U crcmod   && \
+    export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)" && \
+    echo "deb https://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" > /etc/apt/sources.list.d/google-cloud-sdk.list && \
+    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
+    apt-get update && \
+    apt-get install -y google-cloud-sdk \
+        google-cloud-sdk-app-engine-python \
+        google-cloud-sdk-app-engine-java \
+        google-cloud-sdk-app-engine-go \
+        google-cloud-sdk-datalab \
+        google-cloud-sdk-datastore-emulator \
+        google-cloud-sdk-pubsub-emulator \
+        google-cloud-sdk-bigtable-emulator \
+        kubectl && \
     gcloud config set core/disable_usage_reporting true && \
     gcloud config set component_manager/disable_update_check true && \
     gcloud config set metrics/environment github_docker_image

--- a/MAINTENENCE.md
+++ b/MAINTENENCE.md
@@ -1,17 +1,32 @@
 
 
-The Alpine image contains the SHA256 checksum for that version as listed on the SDK [documentation page](https://cloud.google.com/sdk/downloads#versioned).
+
+To publish a new release, update the README with the version to deploy under "Supported tags and respective Dockerfile links"
+
+then
 
 ```bash
-export TAG_VER=153.0.0
-git add -A
-git commit -m "Updating version $TAG_VER"
+export TAG_VER=159.0.0
+git commit -m "Update SDK to 159.0.0"
+
 git push
-git tag $TAG_VER
-git push --tags
+
+git tag -a $TAG_VER
+git push origin $TAG_VER
+
 ```
 
-A github [pre-commit](hooks/pre-commit) hook is also provided which will build the alpine image with the SDK provided. 
+To recreate a tagged version in github and dockerhub, first delete the local and remote tags:
+
+```
+git tag -d 159.0.0
+
+git push origin :159.0.0
+```
+
+After that, you can tag and re-push your current version.  This will trigger a rebuild in dockerhub
+
+A github [pre-commit](hooks/pre-commit) hook is also provided which will build the default image with the SDK provided. 
 
 It requires docker on your build machine so if you have that installed, just copy this file into 
 ```
@@ -21,7 +36,7 @@ Then on git commit, the script will build the image specified and then compare i
 
 If the build does not succeed or gcloud is not initialized with that version, the commit will fail.
 
-You can also pass in the ARG value of the sdk version and checksum as overrides:
+You can also pass in the ARG value of the sdk version and checksum as overrides for aplpine/Dockerfile:
 
 ```bash
 docker build --build-arg CLOUD_SDK_VERSION=151.0.1 --build-arg SHA256SUM=26b84898bc7834664f02b713fd73c7787e62827d2d486f58314cdf1f6f6c56bb -t alpine_151 --no-cache .
@@ -36,4 +51,4 @@ gsutil ls gs://cloud-sdk-release
 * [https://storage.cloud.google.com/cloud-sdk-release](https://storage.cloud.google.com/cloud-sdk-release)
 
 
-
+The Alpine image contains the SHA256 checksum for that version as listed on the SDK [documentation page](https://cloud.google.com/sdk/downloads#versioned).

--- a/README.md
+++ b/README.md
@@ -53,14 +53,13 @@ instance-1  us-central1-a  n1-standard-1               10.240.0.2   8.34.219.29 
 
 ### Installing additional components
 
-By default, all gcloud components are installed on the default image: 
+By default, all gcloud components are installed on the default image:  [https://cloud.google.com/sdk/downloads#apt-get](https://cloud.google.com/sdk/downloads#apt-get)
 
-- [https://cloud.google.com/sdk/downloads#apt-get](https://cloud.google.com/sdk/downloads#apt-get)
-
-The debian-slim image (google/cloud-sdk-docker:alpine:159.0.0-slim), contains no additional components but you are welcome to extend the image or supply --build-args during the build state:
+The :slim image (google/cloud-sdk-docker:alpine:159.0.0-slim), contains no additional components but you are welcome to extend the image or supply --build-args during the build state:
 
 ```
- docker build --build-arg INSTALL_COMPONENTS="google-cloud-sdk-datastore-emulator" -t my-cloud-sdk-docker:159.0.0-slim .
+cd debian_slim/
+docker build --build-arg INSTALL_COMPONENTS="google-cloud-sdk-datastore-emulator" -t my-cloud-sdk-docker:159.0.0-slim .
 ```
 
 
@@ -70,4 +69,4 @@ The original image in this repository was based off of
 
 > FROM gcr.io/google_appengine/base
 
-The full Dockerfile for that can be found [here](google_appengine_base/Dockerfile) for archival as well as in image tag google/cloud-sdk-docker:latest-legacy
+The full Dockerfile for that can be found [here](google_appengine_base/Dockerfile) for archival as well as in image tag google/cloud-sdk-docker:legacy

--- a/README.md
+++ b/README.md
@@ -11,9 +11,8 @@ Image is debian-based and includes default command line tools and all [component
 
 ## Supported tags and respective Dockerfile links
 
-- [159.0.0, latest] (Dockerfile)
-- [159.0.0-slim, latest-slim] (Dockerfile)
-- [latest-legacy] (Dockerfile)
+> * ```google/cloud-sdk:latest```, ```google/cloud-sdk:VERSION```: (large image with additional components pre-installed, Debian-based)
+> * ```google/cloud-sdk:slim```,  ```google/cloud-sdk:VERSION-slim```: (smaller image with no components pre-installed, Debian-based)
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -55,11 +55,11 @@ instance-1  us-central1-a  n1-standard-1               10.240.0.2   8.34.219.29 
 
 By default, all gcloud components are installed on the default image:  [https://cloud.google.com/sdk/downloads#apt-get](https://cloud.google.com/sdk/downloads#apt-get)
 
-The :slim image (google/cloud-sdk-docker:alpine:159.0.0-slim), contains no additional components but you are welcome to extend the image or supply --build-args during the build state:
+The :slim image (google/cloud-sdk-docker:slim), contains no additional components but you are welcome to extend the image or supply --build-args during the build state:
 
 ```
 cd debian_slim/
-docker build --build-arg INSTALL_COMPONENTS="google-cloud-sdk-datastore-emulator" -t my-cloud-sdk-docker:159.0.0-slim .
+docker build --build-arg INSTALL_COMPONENTS="google-cloud-sdk-datastore-emulator" -t my-cloud-sdk-docker:slim .
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -4,14 +4,16 @@
 
 This is Docker image for the [Google Cloud SDK](https://cloud.google.com/sdk/).
 
-Image includes default command line tools:
+Image is debian-based and includes default command line tools and all [components](https://cloud.google.com/sdk/downloads#apt-get) for the SDK.
 *  gcloud:  Default set of gcloud commands
 *  gsutil:  Cloud Storage Command Line Tool
 *  bq: BigQuery Command Line Tool
 
 ## Supported tags and respective Dockerfile links
 
-- [155.0.0, latest] (Dockerfile)
+- [159.0.0, latest] (Dockerfile)
+- [159.0.0-slim, latest-slim] (Dockerfile)
+- [latest-legacy] (Dockerfile)
 
 ## Usage
 
@@ -25,11 +27,7 @@ docker pull google/cloud-sdk:latest
 verify the install
 ```bash
 docker run -ti  google/cloud-sdk:latest gcloud version
-Google Cloud SDK 155.0.0
-bq 2.0.24
-core 2017.05.10
-gcloud 
-gsutil 4.26
+Google Cloud SDK 159.0.0
 ```
 
 or specify a version number:
@@ -56,20 +54,16 @@ instance-1  us-central1-a  n1-standard-1               10.240.0.2   8.34.219.29 
 
 ### Installing additional components
 
-If you need to run additional gcloud components, you need to extend the base image:
+By default, all gcloud components are installed on the default image: 
 
-For example, for appengine-python:
-```dockerfile
-FROM google/cloud-sdk
-RUN gcloud components install app-engine-python
+- [https://cloud.google.com/sdk/downloads#apt-get](https://cloud.google.com/sdk/downloads#apt-get)
+
+The debian-slim image (google/cloud-sdk-docker:alpine:159.0.0-slim), contains no additional components but you are welcome to extend the image or supply --build-args during the build state:
+
+```
+ docker build --build-arg INSTALL_COMPONENTS="google-cloud-sdk-datastore-emulator" -t my-cloud-sdk-docker:159.0.0-slim .
 ```
 
-or for app-engine-java
-```dockerfile
-FROM google/cloud-sdk
-RUN apk --update add openjdk7-jre
-RUN gcloud components install app-engine-java
-```
 
 ### Google App Engine base
 
@@ -77,4 +71,4 @@ The original image in this repository was based off of
 
 > FROM gcr.io/google_appengine/base
 
-The full Dockerfile for that can be found [here](google_appengine_base/Dockerfile) for archival.
+The full Dockerfile for that can be found [here](google_appengine_base/Dockerfile) for archival as well as in image tag google/cloud-sdk-docker:latest-legacy

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,0 +1,15 @@
+FROM alpine:3.5
+ARG CLOUD_SDK_VERSION=159.0.0
+ARG SHA256SUM=5b408575407514f99ad913bd0c6991be4b46408ddc7080a6494bbf43e6ce222a
+ENV PATH /google-cloud-sdk/bin:$PATH
+RUN apk --no-cache add curl python py-crcmod bash libc6-compat && \
+    curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz && \
+    echo "${SHA256SUM}  google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz" > google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz.sha256 && \
+    sha256sum -c google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz.sha256 && \
+    tar xzf google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz && \
+    rm google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz.sha256 && \
+    ln -s /lib /lib64 && \
+    gcloud config set core/disable_usage_reporting true && \
+    gcloud config set component_manager/disable_update_check true && \
+    gcloud config set metrics/environment github_docker_image
+VOLUME ["/root/.config"]

--- a/centos/Dockerfile
+++ b/centos/Dockerfile
@@ -8,10 +8,17 @@ repo_gpgcheck=1\n\
 gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg\n\
        https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg'\
         >> /etc/yum.repos.d/google-cloud-sdk.repo && \
-    yum install -y google-cloud-sdk which gcc python-devel python-setuptools && \
+    yum install -y which gcc python-devel python-setuptools openssh-clients \
+      google-cloud-sdk \
+      google-cloud-sdk-app-engine-python \
+      google-cloud-sdk-app-engine-java \
+      google-cloud-sdk-app-engine-go \
+      google-cloud-sdk-datalab \
+      google-cloud-sdk-datastore-emulator \
+      google-cloud-sdk-pubsub-emulator \
+      kubectl && \
     easy_install -U pip && \
-    pip install -U crcmod && \
-    yum remove -y gcc python-devel python-setuptools && \
+    pip install -U crcmod Pillow && \
     gcloud config set core/disable_usage_reporting true && \
     gcloud config set component_manager/disable_update_check true && \
     gcloud config set metrics/environment github_docker_image

--- a/debian_slim/Dockerfile
+++ b/debian_slim/Dockerfile
@@ -1,13 +1,12 @@
 FROM debian:jessie
+ARG INSTALL_COMPONENTS
 RUN apt-get update && apt-get install -qqy curl gcc python-dev python-setuptools apt-transport-https lsb-release  && \
     easy_install -U pip && \
     pip install -U crcmod && \
     export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)" && \
     echo "deb https://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" > /etc/apt/sources.list.d/google-cloud-sdk.list && \
     curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
-    apt-get update && apt-get install -y google-cloud-sdk && \
-    apt-get -y remove gcc python-dev python-setuptools && \
-    rm -rf /var/lib/apt/lists/* && \    
+    apt-get update && apt-get install -y google-cloud-sdk $INSTALL_COMPONENTS && \
     gcloud config set core/disable_usage_reporting true && \
     gcloud config set component_manager/disable_update_check true && \
     gcloud config set metrics/environment github_docker_image


### PR DESCRIPTION
PR for issue [#74](https://github.com/GoogleCloudPlatform/cloud-sdk-docker/issues/74):

Update baseline image for debian; install all components by default.  Provide -slim and versioned builds.

I'll temp stage the images [here](https://hub.docker.com/r/salrashid123/cloud-sdk-docker/builds/):
  - salrashid123/cloud-sdk-docker:latest
  - salrashid123/cloud-sdk-docker:latest-slim
  - salrashid123/cloud-sdk-docker:159.0.0
  - salrashid123/cloud-sdk-docker:159.0.0-slim
  - salrashid123/cloud-sdk-docker:legacy-latest

for ref: the dockerhub build rules will look like:

![docker_build_settings](https://user-images.githubusercontent.com/11149054/27342772-fbf69418-5595-11e7-99d6-bd2e82398be3.png)
