### PR TITLE
Create versioned and alpine images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM debian:jessie
+ARG CLOUD_SDK_VERSION=160.0.0
 RUN apt-get update && apt-get install -qqy curl gcc python-dev python-setuptools apt-transport-https lsb-release openssh-client && \
     easy_install -U pip && \
     pip install -U crcmod   && \
@@ -6,7 +7,7 @@ RUN apt-get update && apt-get install -qqy curl gcc python-dev python-setuptools
     echo "deb https://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" > /etc/apt/sources.list.d/google-cloud-sdk.list && \
     curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
     apt-get update && \
-    apt-get install -y google-cloud-sdk \
+    apt-get install -y google-cloud-sdk=${CLOUD_SDK_VERSION}-0 \
         google-cloud-sdk-app-engine-python \
         google-cloud-sdk-app-engine-java \
         google-cloud-sdk-app-engine-go \

--- a/MAINTENENCE.md
+++ b/MAINTENENCE.md
@@ -1,17 +1,25 @@
 
 
 
-To publish a new release, update the README with the version to deploy under "Supported tags and respective Dockerfile links"
+To publish a new release, update the README with the version to deploy under "Supported tags and respective Dockerfile links".
+
+Then edit the following files and update the SDK version:
+
+* Dockerfile
+* debian_slim/Dockerfile
+* alpine/Dockerfile
 
 then
 
+finally,
 ```bash
 export TAG_VER=159.0.0
-git commit -m "Update SDK to 159.0.0"
+git add -A
+git commit -m "Update SDK to $TAG_VER"
 
 git push
 
-git tag -a $TAG_VER
+git tag -a $TAG_VER -m "Push $TAG_VER"
 git push origin $TAG_VER
 
 ```
@@ -39,7 +47,7 @@ If the build does not succeed or gcloud is not initialized with that version, th
 You can also pass in the ARG value of the sdk version and checksum as overrides for aplpine/Dockerfile:
 
 ```bash
-docker build --build-arg CLOUD_SDK_VERSION=151.0.1 --build-arg SHA256SUM=26b84898bc7834664f02b713fd73c7787e62827d2d486f58314cdf1f6f6c56bb -t alpine_151 --no-cache .
+docker build --build-arg CLOUD_SDK_VERSION=151.0.1 -t alpine_151 --no-cache .
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Image is debian-based and includes default command line tools and all [component
 
 ## Supported tags and respective Dockerfile links
 
-> * ```google/cloud-sdk:latest```, ```google/cloud-sdk:VERSION```: (large image with additional components pre-installed, Debian-based)
-> * ```google/cloud-sdk:slim```,  ```google/cloud-sdk:VERSION-slim```: (smaller image with no components pre-installed, Debian-based)
+* ```:latest```, ```:VERSION```: (large image with additional components pre-installed, Debian-based)
+* ```:slim```,  ```:VERSION-slim```: (smaller image with no components pre-installed, Debian-based)
 
 ## Usage
 
@@ -55,11 +55,13 @@ instance-1  us-central1-a  n1-standard-1               10.240.0.2   8.34.219.29 
 
 By default, all gcloud components are installed on the default image:  [https://cloud.google.com/sdk/downloads#apt-get](https://cloud.google.com/sdk/downloads#apt-get)
 
-The :slim image (google/cloud-sdk-docker:slim), contains no additional components but you are welcome to extend the image or supply --build-args during the build state:
+You can override any sdk version provided by specifying the CLOUD_SDK_VERSION in as a build-arg.
+
+The :slim image (google/cloud-sdk:slim), contains no additional components but you are welcome to extend the image or supply --build-args during the build state:
 
 ```
 cd debian_slim/
-docker build --build-arg INSTALL_COMPONENTS="google-cloud-sdk-datastore-emulator" -t my-cloud-sdk-docker:slim .
+docker build --build-arg CLOUD_SDK_VERSION=159.0.0 --build-arg INSTALL_COMPONENTS="google-cloud-sdk-datastore-emulator" -t my-cloud-sdk-docker:slim .
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ Image is debian-based and includes default command line tools and all [component
 
 ## Supported tags and respective Dockerfile links
 
-* ```:latest```, ```:VERSION```: (large image with additional components pre-installed, Debian-based)
-* ```:slim```,  ```:VERSION-slim```: (smaller image with no components pre-installed, Debian-based)
+* ```google/cloud-sdk:latest```, ```google/cloud-sdk:VERSION```: (large image with additional components pre-installed, Debian-based)
+* ```google/cloud-sdk:slim```,  ```google/cloud-sdk:VERSION-slim```: (smaller image with no components pre-installed, Debian-based)
+* ```google/cloud-sdk:alpine```,  ```google/cloud-sdk:VERSION-alpine```: (smaller image with no components pre-installed, Alpine-based)
 
 ## Usage
 
@@ -55,15 +56,31 @@ instance-1  us-central1-a  n1-standard-1               10.240.0.2   8.34.219.29 
 
 By default, all gcloud components are installed on the default image:  [https://cloud.google.com/sdk/downloads#apt-get](https://cloud.google.com/sdk/downloads#apt-get)
 
-You can override any sdk version provided by specifying the CLOUD_SDK_VERSION in as a build-arg.
+The google/cloud-sdk:slim and google/cloud-sdk:alpine images do not contain additional components pre-installed. 
+You can extend these images by following the instructions below:
 
-The :slim image (google/cloud-sdk:slim), contains no additional components but you are welcome to extend the image or supply --build-args during the build state:
+
+*Debian*
 
 ```
 cd debian_slim/
 docker build --build-arg CLOUD_SDK_VERSION=159.0.0 --build-arg INSTALL_COMPONENTS="google-cloud-sdk-datastore-emulator" -t my-cloud-sdk-docker:slim .
 ```
 
+*Alpine*
+
+To install additional components for those images, you need to extend the default.  For example, to generate an image that includes kubectl and app-engine-java:
+
+```Dockerfile
+FROM google/cloud-sdk:alpine
+RUN apk --update add openjdk7-jre
+RUN gcloud components install app-engine-java kubectl
+```
+then with that Dockerfile
+
+```
+docker build  -t my-cloud-sdk-docker:alpine .
+```
 
 ### Google App Engine base
 

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,13 +1,10 @@
 FROM alpine:3.5
-ARG CLOUD_SDK_VERSION=159.0.0
-ARG SHA256SUM=5b408575407514f99ad913bd0c6991be4b46408ddc7080a6494bbf43e6ce222a
+ARG CLOUD_SDK_VERSION=160.0.0
 ENV PATH /google-cloud-sdk/bin:$PATH
 RUN apk --no-cache add curl python py-crcmod bash libc6-compat && \
     curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz && \
-    echo "${SHA256SUM}  google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz" > google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz.sha256 && \
-    sha256sum -c google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz.sha256 && \
     tar xzf google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz && \
-    rm google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz.sha256 && \
+    rm google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz && \
     ln -s /lib /lib64 && \
     gcloud config set core/disable_usage_reporting true && \
     gcloud config set component_manager/disable_update_check true && \

--- a/debian_slim/Dockerfile
+++ b/debian_slim/Dockerfile
@@ -1,4 +1,5 @@
 FROM debian:jessie
+ARG CLOUD_SDK_VERSION=160.0.0
 ARG INSTALL_COMPONENTS
 RUN apt-get update && apt-get install -qqy curl gcc python-dev python-setuptools apt-transport-https lsb-release  && \
     easy_install -U pip && \
@@ -6,7 +7,7 @@ RUN apt-get update && apt-get install -qqy curl gcc python-dev python-setuptools
     export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)" && \
     echo "deb https://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" > /etc/apt/sources.list.d/google-cloud-sdk.list && \
     curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
-    apt-get update && apt-get install -y google-cloud-sdk $INSTALL_COMPONENTS && \
+    apt-get update && apt-get install -y google-cloud-sdk=${CLOUD_SDK_VERSION}-0 $INSTALL_COMPONENTS && \
     gcloud config set core/disable_usage_reporting true && \
     gcloud config set component_manager/disable_update_check true && \
     gcloud config set metrics/environment github_docker_image


### PR DESCRIPTION
Update sdk Dockerfiles and specify the version inside the docker file.

Major changes:
- This will allow sources retrieved from github tagged Dockerfiles to reflect the version that should actually get installed.   For example, the Dockerfiles in tag [159.0.0](https://github.com/GoogleCloudPlatform/cloud-sdk-docker/releases/tag/159.0.0)  does not specify the version to install; it'll use whatever is there at time of generation (current in apt repo).

Some suggested improvements:

- add dockerhub build rules for alpine version thats also tagged with the sdk release:  eg  :159.0.0-alpine  and :alpine.


cloud sdk now supports version installs so we can make the changes cited above.
```
# apt-cache policy google-cloud-sdk
google-cloud-sdk:
  Installed: (none)
  Candidate: 159.0.0-0
  Version table:
     159.0.0-0 0
        500 http://packages.cloud.google.com/apt/ cloud-sdk-jessie/main amd64 Packages
     158.0.0-0 0
        500 http://packages.cloud.google.com/apt/ cloud-sdk-jessie/main amd64 Packages
```