### PR TITLE
Split installed packages onto separate lines

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,16 @@
 FROM debian:jessie
 ENV CLOUD_SDK_VERSION 161.0.0
-RUN apt-get update && apt-get install -qqy curl gcc python-dev python-setuptools apt-transport-https lsb-release openssh-client git && \
-    easy_install -U pip && \
+
+RUN apt-get -qqy update && apt-get install -qqy \
+        curl \
+        gcc \
+        python-dev \
+        python-setuptools \
+        apt-transport-https \
+        lsb-release \
+        openssh-client \
+        git \
+    && easy_install -U pip && \
     pip install -U crcmod   && \
     export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)" && \
     echo "deb https://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" > /etc/apt/sources.list.d/google-cloud-sdk.list && \

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,8 +1,16 @@
 FROM alpine:3.5
 ENV CLOUD_SDK_VERSION 161.0.0
+
 ENV PATH /google-cloud-sdk/bin:$PATH
-RUN apk --no-cache add curl python py-crcmod bash libc6-compat openssh-client git && \
-    curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz && \
+RUN apk --no-cache add \
+        curl \
+        python \
+        py-crcmod \
+        bash \
+        libc6-compat \
+        openssh-client \
+        git \
+    && curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz && \
     tar xzf google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz && \
     rm google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz && \
     ln -s /lib /lib64 && \

--- a/debian_slim/Dockerfile
+++ b/debian_slim/Dockerfile
@@ -2,8 +2,16 @@ FROM debian:jessie
 ENV CLOUD_SDK_VERSION 161.0.0
 
 ARG INSTALL_COMPONENTS
-RUN apt-get update && apt-get install -qqy curl gcc python-dev python-setuptools apt-transport-https lsb-release openssh-client git && \
-    easy_install -U pip && \
+RUN apt-get update -qqy && apt-get install -qqy \
+        curl \
+        gcc \
+        python-dev \
+        python-setuptools \
+        apt-transport-https \
+        lsb-release \
+        openssh-client \
+        git \
+    && easy_install -U pip && \
     pip install -U crcmod && \
     export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)" && \
     echo "deb https://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" > /etc/apt/sources.list.d/google-cloud-sdk.list && \


### PR DESCRIPTION
This way it's easier to read the Dockerfiles and patch them simultaneously
with less conflicts.

PTAL @salrashid123