### PR TITLE
add cbt support; upgrade 162

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM debian:jessie
-ENV CLOUD_SDK_VERSION 161.0.0
+ENV CLOUD_SDK_VERSION 162.0.0
 
 RUN apt-get -qqy update && apt-get install -qqy \
         curl \
@@ -24,6 +24,7 @@ RUN apt-get -qqy update && apt-get install -qqy \
         google-cloud-sdk-datastore-emulator \
         google-cloud-sdk-pubsub-emulator \
         google-cloud-sdk-bigtable-emulator \
+        google-cloud-sdk-cbt \
         kubectl && \
     gcloud config set core/disable_usage_reporting true && \
     gcloud config set component_manager/disable_update_check true && \

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:3.5
-ENV CLOUD_SDK_VERSION 161.0.0
+ENV CLOUD_SDK_VERSION 162.0.0
 
 ENV PATH /google-cloud-sdk/bin:$PATH
 RUN apk --no-cache add \

--- a/debian_slim/Dockerfile
+++ b/debian_slim/Dockerfile
@@ -1,5 +1,5 @@
 FROM debian:jessie
-ENV CLOUD_SDK_VERSION 161.0.0
+ENV CLOUD_SDK_VERSION 162.0.0
 
 ARG INSTALL_COMPONENTS
 RUN apt-get update -qqy && apt-get install -qqy \


### PR DESCRIPTION
Adding cbt support;  

added into 162 recently

- [https://cloud.google.com/sdk/downloads#apt-get](https://cloud.google.com/sdk/downloads#apt-get)

google-cloud-sdk-cbt