### PR TITLE
Add docker client to 'thick' image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker:17.06.1-ce as static-docker-source
+FROM docker:17.09.0-ce as static-docker-source
 
 FROM debian:jessie
 ENV CLOUD_SDK_VERSION 171.0.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
+FROM docker:17.06.1-ce as static-docker-source
+
 FROM debian:jessie
 ENV CLOUD_SDK_VERSION 171.0.0
 
+COPY --from=static-docker-source /usr/local/bin/docker /usr/local/bin/docker
 RUN apt-get -qqy update && apt-get install -qqy \
         curl \
         gcc \


### PR DESCRIPTION
The `gcloud docker` subcommand relies on executing a docker client.
This change allows the user to bindmount in the host's docker socket,
and then interact with it using the `gcloud docker` subcommand.

This will only work if the user's host dockerd is compatible with this
docker client, but this is true for all modern versions of docker.

See additional discussion in #97
for why bindmounting in the client's docker binary is non-ideal.

The `docker` image was used to source the docker client binary as a
matter of convenience.

The change is intentionally only applied to the  'debian'
variant of the image, not the 'alpine' nor  '-slim' ones. This is to keep the 'slim'
image slim.

Fixes #97 