### PR TITLE
Add an 'it runs' failsafes to binaries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,5 +28,7 @@ RUN apt-get -qqy update && apt-get install -qqy \
         kubectl && \
     gcloud config set core/disable_usage_reporting true && \
     gcloud config set component_manager/disable_update_check true && \
-    gcloud config set metrics/environment github_docker_image
+    gcloud config set metrics/environment github_docker_image && \
+    gcloud --version && \
+    docker --version && kubectl version --client
 VOLUME ["/root/.config"]

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -16,5 +16,6 @@ RUN apk --no-cache add \
     ln -s /lib /lib64 && \
     gcloud config set core/disable_usage_reporting true && \
     gcloud config set component_manager/disable_update_check true && \
-    gcloud config set metrics/environment github_docker_image
+    gcloud config set metrics/environment github_docker_image && \
+    gcloud --version
 VOLUME ["/root/.config"]

--- a/debian_slim/Dockerfile
+++ b/debian_slim/Dockerfile
@@ -19,5 +19,6 @@ RUN apt-get update -qqy && apt-get install -qqy \
     apt-get update && apt-get install -y google-cloud-sdk=${CLOUD_SDK_VERSION}-0 $INSTALL_COMPONENTS && \
     gcloud config set core/disable_usage_reporting true && \
     gcloud config set component_manager/disable_update_check true && \
-    gcloud config set metrics/environment github_docker_image
+    gcloud config set metrics/environment github_docker_image && \
+    gcloud --version
 VOLUME ["/root/.config"]


### PR DESCRIPTION
This adds a "the binary runs" check to the end of each container's list
of commands.

The primary benefit this has is that a build will fail if any of those
commands don't work, which is preferable to a bad release being made.

As a small secondary benefit, it also includes the `version` output in
the build log.

Ideally, a more complete functional test would be done on each image
prior to push, but since dockerhub automated builds are being used,
there's no great place to insert those tests.

I think this is enough of an improvement to be worth doing.

This was split out from #101 where I originally included it, but was requested to add them separately.