### PR TITLE
Update docker client to 17.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker:17.09.0-ce as static-docker-source
+FROM docker:17.12.0-ce as static-docker-source
 
 FROM debian:jessie
 ENV CLOUD_SDK_VERSION 187.0.0


### PR DESCRIPTION
This updates the docker client included for the `gcloud docker`
subcommand to the current stable version.