### PR TITLE
Add gcsfuse binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,9 @@ RUN apt-get -qqy update && apt-get install -qqy \
     && easy_install -U pip && \
     pip install -U crcmod   && \
     export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)" && \
+    export GCSFUSE_REPO="gcsfuse-$(lsb_release -c -s)" && \
     echo "deb https://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" > /etc/apt/sources.list.d/google-cloud-sdk.list && \
+    echo "deb https://packages.cloud.google.com/apt $GCSFUSE_REPO main" > /etc/apt/sources.list.d/gcsfuse.list && \
     curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
     apt-get update && \
     apt-get install -y google-cloud-sdk=${CLOUD_SDK_VERSION}-0 \
@@ -29,7 +31,8 @@ RUN apt-get -qqy update && apt-get install -qqy \
         google-cloud-sdk-pubsub-emulator=${CLOUD_SDK_VERSION}-0 \
         google-cloud-sdk-bigtable-emulator=${CLOUD_SDK_VERSION}-0 \
         google-cloud-sdk-cbt=${CLOUD_SDK_VERSION}-0 \
-        kubectl && \
+        kubectl \
+        gcsfuse && \
     gcloud config set core/disable_usage_reporting true && \
     gcloud config set component_manager/disable_update_check true && \
     gcloud config set metrics/environment github_docker_image && \

--- a/debian_slim/Dockerfile
+++ b/debian_slim/Dockerfile
@@ -14,7 +14,9 @@ RUN apt-get update -qqy && apt-get install -qqy \
     && easy_install -U pip && \
     pip install -U crcmod && \
     export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)" && \
+    export GCSFUSE_REPO="gcsfuse-$(lsb_release -c -s)" && \
     echo "deb https://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" > /etc/apt/sources.list.d/google-cloud-sdk.list && \
+    echo "deb https://packages.cloud.google.com/apt $GCSFUSE_REPO main" > /etc/apt/sources.list.d/gcsfuse.list && \
     curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
     apt-get update && apt-get install -y google-cloud-sdk=${CLOUD_SDK_VERSION}-0 $INSTALL_COMPONENTS && \
     gcloud config set core/disable_usage_reporting true && \


### PR DESCRIPTION
This PR adds the [GCSFuse](https://github.com/GoogleCloudPlatform/gcsfuse) tool as a component to the cloud sdk image. It is optional in the slim image and bundled in the default image.