### PR TITLE
Replace env with build arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,11 @@ docker build  -t my-cloud-sdk-docker:alpine .
 Note that in this case, you have to install dependencies of additional
 components manually.
 
+### Installing different version of gcloud sdk:
+```
+docker build -t my-cloud-sdk-docker:alpine --build-args CLOUD_SDK_VERSION=<release_number> .
+```
+
 ### Legacy image (Google App Engine based)
 
 The original image in this repository was based off of 

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:3.8
-ENV CLOUD_SDK_VERSION 215.0.0
+ARG CLOUD_SDK_VERSION=215.0.0
 
 ENV PATH /google-cloud-sdk/bin:$PATH
 RUN apk --no-cache add \

--- a/debian_slim/Dockerfile
+++ b/debian_slim/Dockerfile
@@ -1,5 +1,5 @@
 FROM debian:stretch
-ENV CLOUD_SDK_VERSION 215.0.0
+ARG CLOUD_SDK_VERSION=215.0.0
 
 ARG INSTALL_COMPONENTS
 RUN apt-get update -qqy && apt-get install -qqy \


### PR DESCRIPTION
Ability to update gcloud-sdk version through build arguments. Providing the flexibility for the user to use the latest builds instead of waiting for the new image to be published. 