### PR TITLE
Use .tar.gz installer for cloud sdk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM docker:17.12.0-ce as static-docker-source
 FROM debian:stretch
 ARG CLOUD_SDK_VERSION=239.0.0
 ENV CLOUD_SDK_VERSION=$CLOUD_SDK_VERSION
-
+ENV PATH "$PATH:/opt/google-cloud-sdk/bin/"
 COPY --from=static-docker-source /usr/local/bin/docker /usr/local/bin/docker
 RUN apt-get -qqy update && apt-get install -qqy \
         curl \
@@ -17,21 +17,13 @@ RUN apt-get -qqy update && apt-get install -qqy \
         gnupg \
     && easy_install -U pip && \
     pip install -U crcmod   && \
-    export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)" && \
-    echo "deb https://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" > /etc/apt/sources.list.d/google-cloud-sdk.list && \
-    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
-    apt-get update && \
-    apt-get install -y google-cloud-sdk=${CLOUD_SDK_VERSION}-0 \
-        google-cloud-sdk-app-engine-python=${CLOUD_SDK_VERSION}-0 \
-        google-cloud-sdk-app-engine-python-extras=${CLOUD_SDK_VERSION}-0 \
-        google-cloud-sdk-app-engine-java=${CLOUD_SDK_VERSION}-0 \
-        google-cloud-sdk-app-engine-go=${CLOUD_SDK_VERSION}-0 \
-        google-cloud-sdk-datalab=${CLOUD_SDK_VERSION}-0 \
-        google-cloud-sdk-datastore-emulator=${CLOUD_SDK_VERSION}-0 \
-        google-cloud-sdk-pubsub-emulator=${CLOUD_SDK_VERSION}-0 \
-        google-cloud-sdk-bigtable-emulator=${CLOUD_SDK_VERSION}-0 \
-        google-cloud-sdk-cbt=${CLOUD_SDK_VERSION}-0 \
-        kubectl && \
+    mkdir -p /opt && cd /opt && \
+    curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz && \
+    tar xzf google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz && \
+    rm google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz && \
+    gcloud components install -q cbt bigtable datalab gcd-emulator cloud-firestore-emulator pubsub-emulator \
+      cloud_sql_proxy emulator-reverse-proxy cloud-build-local docker-credential-gcr app-engine-java \
+      app-engine-go bq cloud-datastore-emulator core gsutil alpha beta app-engine-python app-engine-php app-engine-python-extras kubectl && \
     gcloud config set core/disable_usage_reporting true && \
     gcloud config set component_manager/disable_update_check true && \
     gcloud config set metrics/environment github_docker_image && \

--- a/debian_slim/Dockerfile
+++ b/debian_slim/Dockerfile
@@ -3,6 +3,7 @@ ARG CLOUD_SDK_VERSION=239.0.0
 ENV CLOUD_SDK_VERSION=$CLOUD_SDK_VERSION
 
 ARG INSTALL_COMPONENTS
+ENV PATH "$PATH:/opt/google-cloud-sdk/bin/"
 RUN apt-get update -qqy && apt-get install -qqy \
         curl \
         gcc \
@@ -16,11 +17,13 @@ RUN apt-get update -qqy && apt-get install -qqy \
     && easy_install -U pip && \
     pip install -U crcmod && \
     export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)" && \
-    echo "deb https://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" > /etc/apt/sources.list.d/google-cloud-sdk.list && \
-    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
-    apt-get update && apt-get install -y google-cloud-sdk=${CLOUD_SDK_VERSION}-0 $INSTALL_COMPONENTS && \
+    mkdir -p /opt && cd /opt && \
+    curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz && \
+    tar xzf google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz && \
+    rm google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz && \
     gcloud config set core/disable_usage_reporting true && \
     gcloud config set component_manager/disable_update_check true && \
     gcloud config set metrics/environment github_docker_image && \
     gcloud --version
+
 VOLUME ["/root/.config"]


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/cloud-sdk-docker/issues/94

Instlals `gcloud` under `/opt/google-cloud-sdk/` and adds to the path

Updated `Dockerfile` has
```
Your current Cloud SDK version is: 239.0.0
The latest available version is: 239.0.0

+---------------------------------------------------------------------------------------------------------+
|                                                Components                                               |
+-----------+------------------------------------------------------+--------------------------+-----------+
|   Status  |                         Name                         |            ID            |    Size   |
+-----------+------------------------------------------------------+--------------------------+-----------+
| Installed | App Engine Go Extensions                             | app-engine-go            |  56.6 MiB |
| Installed | BigQuery Command Line Tool                           | bq                       |   < 1 MiB |
| Installed | Cloud Bigtable Command Line Tool                     | cbt                      |   6.4 MiB |
| Installed | Cloud Bigtable Emulator                              | bigtable                 |   5.6 MiB |
| Installed | Cloud Datalab Command Line Tool                      | datalab                  |   < 1 MiB |
| Installed | Cloud Datastore Emulator                             | cloud-datastore-emulator |  18.4 MiB |
| Installed | Cloud Datastore Emulator (Legacy)                    | gcd-emulator             |  38.1 MiB |
| Installed | Cloud Firestore Emulator                             | cloud-firestore-emulator |  39.2 MiB |
| Installed | Cloud Pub/Sub Emulator                               | pubsub-emulator          |  33.4 MiB |
| Installed | Cloud SDK Core Libraries                             | core                     |   9.9 MiB |
| Installed | Cloud SQL Proxy                                      | cloud_sql_proxy          |   3.8 MiB |
| Installed | Cloud Storage Command Line Tool                      | gsutil                   |   3.6 MiB |
| Installed | Emulator Reverse Proxy                               | emulator-reverse-proxy   |  14.5 MiB |
| Installed | Google Cloud Build Local Builder                     | cloud-build-local        |   6.0 MiB |
| Installed | Google Container Registry's Docker credential helper | docker-credential-gcr    |   1.8 MiB |
| Installed | gcloud Alpha Commands                                | alpha                    |   < 1 MiB |
| Installed | gcloud Beta Commands                                 | beta                     |   < 1 MiB |
| Installed | gcloud app Java Extensions                           | app-engine-java          | 108.8 MiB |
| Installed | gcloud app PHP Extensions                            | app-engine-php           |           |
| Installed | gcloud app Python Extensions                         | app-engine-python        |   6.0 MiB |
| Installed | gcloud app Python Extensions (Extra Libraries)       | app-engine-python-extras |  28.5 MiB |
| Installed | kubectl                                              | kubectl                  |   < 1 MiB |
+-----------+------------------------------------------------------+--------------------------+-----------+
```

---

Update `debian_slim` has:

```
Your current Cloud SDK version is: 239.0.0
The latest available version is: 239.0.0

+-------------------------------------------------------------------------------------------------------------+
|                                                  Components                                                 |
+---------------+------------------------------------------------------+--------------------------+-----------+
|     Status    |                         Name                         |            ID            |    Size   |
+---------------+------------------------------------------------------+--------------------------+-----------+
| Not Installed | App Engine Go Extensions                             | app-engine-go            |  56.6 MiB |
| Not Installed | Cloud Bigtable Command Line Tool                     | cbt                      |   6.4 MiB |
| Not Installed | Cloud Bigtable Emulator                              | bigtable                 |   5.6 MiB |
| Not Installed | Cloud Datalab Command Line Tool                      | datalab                  |   < 1 MiB |
| Not Installed | Cloud Datastore Emulator                             | cloud-datastore-emulator |  18.4 MiB |
| Not Installed | Cloud Datastore Emulator (Legacy)                    | gcd-emulator             |  38.1 MiB |
| Not Installed | Cloud Firestore Emulator                             | cloud-firestore-emulator |  39.2 MiB |
| Not Installed | Cloud Pub/Sub Emulator                               | pubsub-emulator          |  33.4 MiB |
| Not Installed | Cloud SQL Proxy                                      | cloud_sql_proxy          |   3.8 MiB |
| Not Installed | Emulator Reverse Proxy                               | emulator-reverse-proxy   |  14.5 MiB |
| Not Installed | Google Cloud Build Local Builder                     | cloud-build-local        |   6.0 MiB |
| Not Installed | Google Container Registry's Docker credential helper | docker-credential-gcr    |   1.8 MiB |
| Not Installed | gcloud Alpha Commands                                | alpha                    |   < 1 MiB |
| Not Installed | gcloud Beta Commands                                 | beta                     |   < 1 MiB |
| Not Installed | gcloud app Java Extensions                           | app-engine-java          | 108.8 MiB |
| Not Installed | gcloud app PHP Extensions                            | app-engine-php           |           |
| Not Installed | gcloud app Python Extensions                         | app-engine-python        |   6.0 MiB |
| Not Installed | gcloud app Python Extensions (Extra Libraries)       | app-engine-python-extras |  28.5 MiB |
| Not Installed | kubectl                                              | kubectl                  |   < 1 MiB |
| Installed     | BigQuery Command Line Tool                           | bq                       |   < 1 MiB |
| Installed     | Cloud SDK Core Libraries                             | core                     |   9.9 MiB |
| Installed     | Cloud Storage Command Line Tool                      | gsutil                   |   3.6 MiB |
+---------------+------------------------------------------------------+--------------------------+-----------+
```