### PR TITLE
Add docker client to slim and alpine

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,8 +1,11 @@
+FROM docker:17.12.0-ce as static-docker-source
+
 FROM alpine:3.9
 ARG CLOUD_SDK_VERSION=241.0.0
 ENV CLOUD_SDK_VERSION=$CLOUD_SDK_VERSION
 
 ENV PATH /google-cloud-sdk/bin:$PATH
+COPY --from=static-docker-source /usr/local/bin/docker /usr/local/bin/docker
 RUN apk --no-cache add \
         curl \
         python \

--- a/debian_slim/Dockerfile
+++ b/debian_slim/Dockerfile
@@ -1,9 +1,12 @@
+FROM docker:17.12.0-ce as static-docker-source
+
 FROM debian:stretch
 ARG CLOUD_SDK_VERSION=241.0.0
 ENV CLOUD_SDK_VERSION=$CLOUD_SDK_VERSION
 
 ARG INSTALL_COMPONENTS
 ENV PATH "$PATH:/opt/google-cloud-sdk/bin/"
+COPY --from=static-docker-source /usr/local/bin/docker /usr/local/bin/docker
 RUN apt-get update -qqy && apt-get install -qqy \
         curl \
         gcc \


### PR DESCRIPTION
This change adds Docker to the Slim and Alpine image variants using the same model in the main Dockerfile.

The main container image is in the ~700MB zone.

For a baseline CI/CD use case, many of the extra packages there may not be needed, but it's very likely that docker will be. I have seen a number of alpine glcoud + docker images in the wild. In practice, the size difference can save minutes off a pipeline with multiple jobs on a service such as GitLab CI or CircleCI.
