### PR TITLE
Install envsubst since often used with kubectl apply.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get -qqy update && apt-get install -qqy \
         openssh-client \
         git \
         gnupg \
+        gettext-base \
     && easy_install -U pip && \
     pip install -U crcmod   && \
     export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)" && \


### PR DESCRIPTION
The `envsubst` command is part of an so often used pattern to substitute environment variables when using `kubectl` in CI pipelines that it seems to make sense to have it available in the fatter image.

Example:

    export IMAGE_SHA1=abcde
    cat manifest.yaml | envsubst | kubectl apply -f -
