### PR TITLE
add make from package managers in non-appengine Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ COPY --from=static-docker-source /usr/local/bin/docker /usr/local/bin/docker
 RUN apt-get -qqy update && apt-get install -qqy \
         curl \
         gcc \
+        make \
         python-dev \
         python-setuptools \
         apt-transport-https \

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -5,6 +5,7 @@ ENV CLOUD_SDK_VERSION=$CLOUD_SDK_VERSION
 ENV PATH /google-cloud-sdk/bin:$PATH
 RUN apk --no-cache add \
         curl \
+        make \
         python \
         py-crcmod \
         bash \

--- a/debian_slim/Dockerfile
+++ b/debian_slim/Dockerfile
@@ -7,6 +7,7 @@ ENV PATH "$PATH:/opt/google-cloud-sdk/bin/"
 RUN apt-get update -qqy && apt-get install -qqy \
         curl \
         gcc \
+        make \
         python-dev \
         python-setuptools \
         apt-transport-https \


### PR DESCRIPTION
`make` is useful and (near) ubiquitous. Adding to these images will help in many use cases: Docker-based CI/CD systems, automating `gcloud` using `make`, etc.