### PR TITLE
add VOLUME .kube

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,4 +34,5 @@ RUN apt-get -qqy update && apt-get install -qqy \
         kubectl && \
     gcloud --version && \
     docker --version && kubectl version --client
-VOLUME ["/root/.config"]
+VOLUME ["/root/.config", "/root/.kube"]
+


### PR DESCRIPTION
```
docker run --rm --volumes-from my-project google/cloud-sdk gcloud container clusters get-credentials my-cluster --project my-project #set up .kube
docker run --rm --volumes-from my-project google/cloud-sdk kubectl get pod
The connection to the server localhost:8080 was refused - did you specify the right host or port?
```
I think it would be more appropriate that kubectl config should be persisted when we use `docker run --volume-from`.