### PR TITLE
Use non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,5 +36,7 @@ RUN apt-get -qqy update && apt-get install -qqy \
         kubectl && \
     gcloud --version && \
     docker --version && kubectl version --client
-VOLUME ["/root/.config", "/root/.kube"]
+RUN useradd -ms /bin/bash user
+USER user
+VOLUME ["~/.config", "~/.kube"]
 


### PR DESCRIPTION
Follow Google best practices:

https://cloud.google.com/solutions/best-practices-for-operating-containers#avoid_running_as_root