### PR TITLE
README: explain how to authenticate API clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,16 @@ or use a particular version number:
 docker run gcr.io/google.com/cloudsdktool/cloud-sdk:260.0.0 gcloud version
 ```
 
-Then, authenticate by running:
+You can authenticate `gcloud` with your user credentials by running [`gcloud auth login`](https://cloud.google.com/sdk/gcloud/reference/auth/login):
 
 ```
 docker run -ti --name gcloud-config gcr.io/google.com/cloudsdktool/cloud-sdk gcloud auth login
+```
+
+If you need to authenticate any program that uses the Google Cloud APIs, you need to pass the `--update-adc` option:
+
+```
+docker run -ti --name gcloud-config gcr.io/google.com/cloudsdktool/cloud-sdk gcloud auth login --update-adc
 ```
 
 Once you authenticate successfully, credentials are preserved in the volume of


### PR DESCRIPTION
`gcloud auth login` is not enough to authenticate the applications using Google Cloud APIs (e.g., the `Client` of `google-cloud-bigquery`): to update the Application Default Credentials the `--update-adc` option is required.

This PR adds this explanation to the README.md.