### PR TITLE
Updated table: kubectl is not included with :slim, see #174

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ project_id1          GCPAppID     1071284184432
 |           gcloud app Java Extensions           |    x    |         |       |            x            |
 |          gcloud app Python Extensions          |    x    |         |       |            x            |
 | gcloud app Python Extensions (Extra Libraries) |    x    |         |       |            x            |
-|                     kubectl                    |    x    |         |   x   |            x            |
+|                     kubectl                    |    x    |         |       |            x            |
 
 ### Installing additional components
 


### PR DESCRIPTION
https://github.com/GoogleCloudPlatform/cloud-sdk-docker/issues/174