### PR TITLE
Allow image to be run as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ ENV CLOUD_SDK_VERSION=$CLOUD_SDK_VERSION
 ENV CLOUDSDK_PYTHON=python3
 ENV PATH "$PATH:/opt/google-cloud-sdk/bin/"
 COPY --from=static-docker-source /usr/local/bin/docker /usr/local/bin/docker
+RUN groupadd -r -g 1000 cloudsdk && \
+    useradd -r -u 1000 -m -s /bin/bash -g cloudsdk cloudsdk
 RUN apt-get -qqy update && apt-get install -qqy \
         curl \
         python3-dev \
@@ -39,4 +41,5 @@ RUN apt-get install -qqy \
         gcc \
         python3-pip
 RUN git config --system credential.'https://source.developers.google.com'.helper gcloud.sh
+USER cloudsdk
 VOLUME ["~/.config", "~/.kube"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,5 +39,4 @@ RUN apt-get install -qqy \
         gcc \
         python3-pip
 RUN git config --system credential.'https://source.developers.google.com'.helper gcloud.sh
-VOLUME ["/root/.config", "/root/.kube"]
-
+VOLUME ["~/.config", "~/.kube"]

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -7,6 +7,8 @@ ENV CLOUDSDK_PYTHON=python3
 
 ENV PATH /google-cloud-sdk/bin:$PATH
 COPY --from=static-docker-source /usr/local/bin/docker /usr/local/bin/docker
+RUN addgroup -g 1000 -S cloudsdk && \
+    adduser -u 1000 -S cloudsdk -G cloudsdk
 RUN apk --no-cache add \
         curl \
         python3 \
@@ -24,4 +26,5 @@ RUN apk --no-cache add \
     gcloud config set metrics/environment github_docker_image && \
     gcloud --version
 RUN git config --system credential.'https://source.developers.google.com'.helper gcloud.sh
+USER cloudsdk
 VOLUME ["~/.config"]

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -24,4 +24,4 @@ RUN apk --no-cache add \
     gcloud config set metrics/environment github_docker_image && \
     gcloud --version
 RUN git config --system credential.'https://source.developers.google.com'.helper gcloud.sh
-VOLUME ["/root/.config"]
+VOLUME ["~/.config"]

--- a/debian_component_based/Dockerfile
+++ b/debian_component_based/Dockerfile
@@ -6,6 +6,8 @@ ENV CLOUD_SDK_VERSION=$CLOUD_SDK_VERSION
 ENV PATH /google-cloud-sdk/bin:$PATH
 ENV CLOUDSDK_PYTHON=python3
 COPY --from=static-docker-source /usr/local/bin/docker /usr/local/bin/docker
+RUN groupadd -r -g 1000 cloudsdk && \
+    useradd -r -u 1000 -m -s /bin/bash -g cloudsdk cloudsdk
 RUN apt-get -qqy update && apt-get install -qqy \
         curl \
         gcc \
@@ -26,4 +28,5 @@ RUN /google-cloud-sdk/install.sh --bash-completion=false --path-update=true --us
 	pubsub-emulator cloud-datastore-emulator app-engine-go bigtable cbt datalab \
 	app-engine-python-extras kubectl
 RUN git config --system credential.'https://source.developers.google.com'.helper gcloud.sh
+USER cloudsdk
 VOLUME ["~/.config", "~/.kube"]

--- a/debian_component_based/Dockerfile
+++ b/debian_component_based/Dockerfile
@@ -26,4 +26,4 @@ RUN /google-cloud-sdk/install.sh --bash-completion=false --path-update=true --us
 	pubsub-emulator cloud-datastore-emulator app-engine-go bigtable cbt datalab \
 	app-engine-python-extras kubectl
 RUN git config --system credential.'https://source.developers.google.com'.helper gcloud.sh
-VOLUME ["/root/.config", "/root/.kube"]
+VOLUME ["~/.config", "~/.kube"]

--- a/debian_slim/Dockerfile
+++ b/debian_slim/Dockerfile
@@ -8,6 +8,8 @@ ENV CLOUDSDK_PYTHON=python3
 ARG INSTALL_COMPONENTS
 ENV PATH "$PATH:/opt/google-cloud-sdk/bin/"
 COPY --from=static-docker-source /usr/local/bin/docker /usr/local/bin/docker
+RUN groupadd -r -g 1000 cloudsdk && \
+    useradd -r -u 1000 -m -s /bin/bash -g cloudsdk cloudsdk
 RUN apt-get update -qqy && apt-get install -qqy \
         curl \
         gcc \
@@ -30,4 +32,5 @@ RUN apt-get update -qqy && apt-get install -qqy \
 
 RUN git config --system credential.'https://source.developers.google.com'.helper gcloud.sh
 
+USER cloudsdk
 VOLUME ["~/.config"]

--- a/debian_slim/Dockerfile
+++ b/debian_slim/Dockerfile
@@ -30,4 +30,4 @@ RUN apt-get update -qqy && apt-get install -qqy \
 
 RUN git config --system credential.'https://source.developers.google.com'.helper gcloud.sh
 
-VOLUME ["/root/.config"]
+VOLUME ["~/.config"]


### PR DESCRIPTION
As per GCP's [best practices](https://cloud.google.com/solutions/best-practices-for-operating-containers#avoid_running_as_root), it is recommended not to run containers as the `root` user.

Fixes #154 
Fixes #199 