### PR TITLE
Add local-extract by default to the gcloud installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,7 @@ RUN apt-get -qqy update && apt-get install -qqy \
         google-cloud-sdk-firestore-emulator=${CLOUD_SDK_VERSION}-0 \
         google-cloud-sdk-spanner-emulator=${CLOUD_SDK_VERSION}-0 \
         google-cloud-sdk-cbt=${CLOUD_SDK_VERSION}-0 \
+        google-cloud-sdk-local-extract=${CLOUD_SDK_VERSION}-0 \
         kubectl && \
     gcloud --version && \
     docker --version && kubectl version --client

--- a/debian_component_based/Dockerfile
+++ b/debian_component_based/Dockerfile
@@ -24,6 +24,6 @@ RUN /google-cloud-sdk/install.sh --bash-completion=false --path-update=true --us
 	--additional-components app-engine-java app-engine-python alpha beta \
 	pubsub-emulator cloud-datastore-emulator app-engine-go bigtable cbt datalab \
 	app-engine-python-extras kubectl appctl kustomize minikube nomos skaffold anthos-auth \
-	kpt
+	kpt local-extract
 RUN git config --system credential.'https://source.developers.google.com'.helper gcloud.sh
 VOLUME ["/root/.config", "/root/.kube"]


### PR DESCRIPTION
This component is needed to scan using the On-Demand Scanning API (https://cloud.google.com/container-analysis/docs/on-demand-scanning). Adding it by default eliminates friction for users initiating scans using this image, such as during a step in a Cloud Build invocation.