### PR TITLE
Fix dind for alpine based image

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ project_id1          GCPAppID     1071284184432
 | kpt                                                  |    x    |         |       |            x            |            |
 | kubectl                                              |    x    |         |       |            x            |            |
 | local-extract                                        |    x    |         |       |            x            |            |
+| Docker in Docker (dind)                              |         |    x    |       |                         |            |
 
 
 ### Installing additional components

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,10 +1,8 @@
-FROM docker:19.03.11 as static-docker-source
+FROM docker:19.03.11
 
-FROM alpine:3.13
 ARG CLOUD_SDK_VERSION=341.0.0
 ENV CLOUD_SDK_VERSION=$CLOUD_SDK_VERSION
 ENV PATH /google-cloud-sdk/bin:$PATH
-COPY --from=static-docker-source /usr/local/bin/docker /usr/local/bin/docker
 RUN addgroup -g 1000 -S cloudsdk && \
     adduser -u 1000 -S cloudsdk -G cloudsdk
 RUN apk --no-cache add \


### PR DESCRIPTION
When using the `google/cloud-sdk` docker image, docker in docker doesn’t work. For example `docker pull` doesn’t work. However, when using the `docker` docker image, and install the Google Cloud SDK it does work.

This change literally bases the `google/cloud-sdk` docker image on the `docker` image, making dind work. The `docker` image is also based on `alpine:3.13`.