### PR TITLE
emulators: add a step to rm cache and tmp files

### DIFF
--- a/emulators/Dockerfile
+++ b/emulators/Dockerfile
@@ -35,8 +35,8 @@ RUN ARCH=`cat /tmp/arch` && \
     find /google-cloud-sdk/ -name "__pycache__" -type d  | xargs -n 1 rm -rf && \
     rm -rf /var/lib/apt/lists \
            tmp/* \
-           google-cloud-sdk/platform/gsutil/third_party/pyparsing/.idea \
+           google-cloud-sdk/platform/ext-runtime/go/data/Dockerfile \
            google-cloud-sdk/platform/ext-runtime/nodejs/data/Dockerfile \
-           google-cloud-sdk/platform/gsutil/third_party/google-auth-library-python/.kokoro/docker/docs/Dockerfile \
-           google-cloud-sdk/platform/ext-runtime/go/data/Dockerfile
+           google-cloud-sdk/platform/gsutil/third_party/pyparsing/.idea \
+           google-cloud-sdk/platform/gsutil/third_party/google-auth-library-python/.kokoro/docker/docs/Dockerfile
 

--- a/emulators/Dockerfile
+++ b/emulators/Dockerfile
@@ -32,5 +32,6 @@ RUN ARCH=`cat /tmp/arch` && \
     gcloud components install beta `cat /tmp/additional_components` && \
     rm /google-cloud-sdk/data/cli/gcloud.json && \
     rm -rf /google-cloud-sdk/.install/.backup/ && \
-    find /google-cloud-sdk/ -name "__pycache__" -type d  | xargs -n 1 rm -rf
+    find /google-cloud-sdk/ -name "__pycache__" -type d  | xargs -n 1 rm -rf && \
+    rm -rf /var/lib/apt/lists
 

--- a/emulators/Dockerfile
+++ b/emulators/Dockerfile
@@ -33,5 +33,10 @@ RUN ARCH=`cat /tmp/arch` && \
     rm /google-cloud-sdk/data/cli/gcloud.json && \
     rm -rf /google-cloud-sdk/.install/.backup/ && \
     find /google-cloud-sdk/ -name "__pycache__" -type d  | xargs -n 1 rm -rf && \
-    rm -rf /var/lib/apt/lists
+    rm -rf /var/lib/apt/lists \
+           tmp/* \
+           google-cloud-sdk/platform/gsutil/third_party/pyparsing/.idea \
+           google-cloud-sdk/platform/ext-runtime/nodejs/data/Dockerfile \
+           google-cloud-sdk/platform/gsutil/third_party/google-auth-library-python/.kokoro/docker/docs/Dockerfile \
+           google-cloud-sdk/platform/ext-runtime/go/data/Dockerfile
 

--- a/emulators/Dockerfile
+++ b/emulators/Dockerfile
@@ -33,10 +33,4 @@ RUN ARCH=`cat /tmp/arch` && \
     rm /google-cloud-sdk/data/cli/gcloud.json && \
     rm -rf /google-cloud-sdk/.install/.backup/ && \
     find /google-cloud-sdk/ -name "__pycache__" -type d  | xargs -n 1 rm -rf && \
-    rm -rf /var/lib/apt/lists \
-           tmp/* \
-           google-cloud-sdk/platform/ext-runtime/go/data/Dockerfile \
-           google-cloud-sdk/platform/ext-runtime/nodejs/data/Dockerfile \
-           google-cloud-sdk/platform/gsutil/third_party/pyparsing/.idea \
-           google-cloud-sdk/platform/gsutil/third_party/google-auth-library-python/.kokoro/docker/docs/Dockerfile
-
+    rm -rf /var/lib/apt/lists tmp/*


### PR DESCRIPTION
```sh
$ dockle gcr.io/google.com/cloudsdktool/google-cloud-cli:386.0.0-emulators
...
FATAL	- DKL-DI-0005: Clear apt-get caches
	* Use 'rm -rf /var/lib/apt/lists' after 'apt-get install|update' : RUN |1 CLOUD_SDK_VERSION=386.0.0 /bin/sh -c ARCH=`cat /tmp/arch` &&     mkdir -p /usr/share/man/man1/ &&     apt-get update &&     apt-get -y install         curl         python3         python3-crcmod         bash         openjdk-11-jre-headless &&     curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-${ARCH}.tar.gz &&     tar xzf google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-${ARCH}.tar.gz &&     rm google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-${ARCH}.tar.gz &&     gcloud config set core/disable_usage_reporting true &&     gcloud config set component_manager/disable_update_check true &&     gcloud config set metrics/environment github_docker_image_emulator &&     gcloud components remove anthoscli &&     gcloud components install beta `cat /tmp/additional_components` &&     rm /google-cloud-sdk/data/cli/gcloud.json &&     rm -rf /google-cloud-sdk/.install/.backup/ &&     find /google-cloud-sdk/ -name "__pycache__" -type d  | xargs -n 1 rm -rf # buildkit
...
INFO	- DKL-LI-0003: Only put necessary files
	* Suspicious directory : google-cloud-sdk/platform/gsutil/third_party/pyparsing/.idea
	* unnecessary file : google-cloud-sdk/platform/ext-runtime/nodejs/data/Dockerfile
	* Suspicious directory : tmp
	* unnecessary file : google-cloud-sdk/platform/gsutil/third_party/google-auth-library-python/.kokoro/docker/docs/Dockerfile
	* unnecessary file : google-cloud-sdk/platform/ext-runtime/go/data/Dockerfile
```

To fix `dockle` error `DKL-DI-0005` and a part of `DKL-LI-0003`, I add a step to remove cache and tmp files in emulators image.