### PR TITLE
Update images to use Debian Bullseye as base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM docker:20.10.12 as static-docker-source
 
-FROM debian:buster
+FROM debian:bullseye
 ARG CLOUD_SDK_VERSION=390.0.0
 ENV CLOUD_SDK_VERSION=$CLOUD_SDK_VERSION
 ENV PATH "$PATH:/opt/google-cloud-sdk/bin/"
@@ -45,4 +45,3 @@ RUN pip3 install --upgrade pip
 RUN pip3 install pyopenssl
 RUN git config --system credential.'https://source.developers.google.com'.helper gcloud.sh
 VOLUME ["/root/.config", "/root/.kube"]
-

--- a/debian_component_based/Dockerfile
+++ b/debian_component_based/Dockerfile
@@ -1,6 +1,6 @@
 FROM docker:20.10.12 as static-docker-source
 
-FROM debian:buster
+FROM debian:bullseye
 ARG CLOUD_SDK_VERSION=390.0.0
 ENV CLOUD_SDK_VERSION=$CLOUD_SDK_VERSION
 ENV PATH /google-cloud-sdk/bin:$PATH

--- a/debian_slim/Dockerfile
+++ b/debian_slim/Dockerfile
@@ -1,6 +1,6 @@
 FROM docker:20.10.12 as static-docker-source
 
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 ARG CLOUD_SDK_VERSION=390.0.0
 ENV CLOUD_SDK_VERSION=$CLOUD_SDK_VERSION
 ENV PATH "$PATH:/opt/google-cloud-sdk/bin/"

--- a/emulators/Dockerfile
+++ b/emulators/Dockerfile
@@ -1,5 +1,5 @@
-# debian:buster-slim is used instead of alpine because the cloud bigtable emulator requires glibc.
-FROM debian:buster-slim
+# debian:bullseye-slim is used instead of alpine because the cloud bigtable emulator requires glibc.
+FROM debian:bullseye-slim
 
 ARG CLOUD_SDK_VERSION=390.0.0
 ENV CLOUD_SDK_VERSION=$CLOUD_SDK_VERSION


### PR DESCRIPTION
Per https://github.com/GoogleCloudPlatform/cloud-sdk-docker/issues/272#issuecomment-1091877037, Debian Buster is EOL in August 2022. 

This PR updates base images to `debian:bullseye` and closes #272 