### PR TITLE
Remove Local Builder details.

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,6 @@ You can set any Cloud SDK property via an ENV,
 | Cloud SQL Proxy                                      |         |         |       |                         |            |
 | Cloud Spanner Emulator                               |    x    |         |       |                         |     x      |
 | Cloud Storage Command Line Tool                      |    x    |    x    |   x   |            x            |            |
-| Google Cloud Build Local Builder                     |         |         |       |                         |            |
 | Google Container Registry's Docker credential helper |         |         |       |                         |            |
 | Kustomize                                            |         |         |       |                         |            |
 | Minikube                                             |         |         |       |                         |            |


### PR DESCRIPTION
Cloud Build Local Builder is obsolete. While it is still included for installation via Cloud SDK, it is hidden and its use is no longer supported.