### PR TITLE
add missing jre to debian_component_based image

### DIFF
--- a/debian_component_based/Dockerfile
+++ b/debian_component_based/Dockerfile
@@ -1,6 +1,5 @@
 FROM docker:20.10.12 as static-docker-source
 
-
 FROM debian:bullseye
 ARG CLOUD_SDK_VERSION=405.0.0
 ENV CLOUD_SDK_VERSION=$CLOUD_SDK_VERSION
@@ -19,7 +18,8 @@ RUN apt-get -qqy update && apt-get install -qqy \
         openssh-client \
         git \
         make \
-        gnupg
+        gnupg \
+        openjdk-11-jre-headless
 RUN if [ `uname -m` = 'x86_64' ]; then echo -n "x86_64" > /tmp/arch; else echo -n "arm" > /tmp/arch; fi;
 RUN ARCH=`cat /tmp/arch` && curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-${ARCH}.tar.gz && \
     tar xzf google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-${ARCH}.tar.gz && \


### PR DESCRIPTION
fixes: #290

this pr would add `openjdk-11-jre-headless` as it's currently used in the [emulators/Dockerfile](https://github.com/GoogleCloudPlatform/cloud-sdk-docker/blob/b1077cac9dd65fb372a1e5c8ecfc10c38592953c/emulators/Dockerfile#L24)

**_before_** this pr, there was an error described in the issue #290 that prevented the pub/sub emulator from starting

**_after_** this pr, the logs show the correct startup:
```
DEBUG: Running [gcloud.beta.emulators.pubsub.start] with arguments: [--host-port: "<googlecloudsdk.calliope.arg_parsers.HostPort object at 0xffff96221850>", --log-http: "true", --project: "localrun", --user-output-enabled: "true", --verbosity: "debug"]
DEBUG: Found Cloud SDK root: /google-cloud-sdk
Executing: /google-cloud-sdk/platform/pubsub-emulator/bin/cloud-pubsub-emulator --host=0.0.0.0 --port=8085
[pubsub] This is the Google Pub/Sub fake.
[pubsub] Implementation may be incomplete or differ from the real system.
[pubsub] Oct 07, 2022 5:22:28 PM com.google.cloud.pubsub.testing.v1.Main main
[pubsub] INFO: IAM integration is disabled. IAM policy methods and ACL checks are not supported
[pubsub] SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
[pubsub] SLF4J: Defaulting to no-operation (NOP) logger implementation
[pubsub] SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
[pubsub] Oct 07, 2022 5:22:28 PM com.google.cloud.pubsub.testing.v1.Main main
[pubsub] INFO: Server started, listening on 8085
[pubsub] Oct 07, 2022 5:22:32 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
[pubsub] INFO: Detected HTTP/2 connection.
...
```