### PR TITLE
Update static docker source to v20.10.21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker:20.10.12 as static-docker-source
+FROM docker:20.10.21 as static-docker-source
 
 FROM debian:bullseye
 ARG CLOUD_SDK_VERSION=409.0.0

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker:20.10.12 as static-docker-source
+FROM docker:20.10.21 as static-docker-source
 
 FROM alpine:3.15
 ARG CLOUD_SDK_VERSION=409.0.0

--- a/debian_component_based/Dockerfile
+++ b/debian_component_based/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker:20.10.12 as static-docker-source
+FROM docker:20.10.21 as static-docker-source
 
 FROM debian:bullseye
 ARG CLOUD_SDK_VERSION=409.0.0

--- a/debian_slim/Dockerfile
+++ b/debian_slim/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker:20.10.12 as static-docker-source
+FROM docker:20.10.21 as static-docker-source
 
 FROM debian:bullseye-slim
 ARG CLOUD_SDK_VERSION=409.0.0


### PR DESCRIPTION
The latest docker releases contain several security fixes.

I suggest to update the old docker binary to fix more than 23 vulnerabilities (result by Google Cloud Container Analysis scanning API) in Google Cloud CLI Docker image.

For more details check the CVEs on the release page
https://github.com/moby/moby/releases