### PR TITLE
Remove pyopenssl python package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,5 @@ RUN apt-get -qqy update && apt-get install -qqy \
 RUN apt-get install -qqy \
         gcc \
         python3-pip
-RUN pip3 install --upgrade pip
-RUN pip3 install pyopenssl
 RUN git config --system credential.'https://source.developers.google.com'.helper gcloud.sh
 VOLUME ["/root/.config", "/root/.kube"]


### PR DESCRIPTION
Cause of #230 the pyopenssl python package was added to the `:latest` Dockerfile as a dependency of `gsutil signurl`.

Tried the `:slim` Docker image (already/still) without pyopenssl and the `gsutil signurl` command is running without an issue.
Removing pyopenssl in `:latest` does not break the `gsutil signurl` command.

```
gsutil signurl -r <region> <private-key-file> gs://<bucket>/<object> 
```

Is it safe to remove the 'unused' python package in the latest Debian based Docker image? Or are there different dependency to the pyopenssl package?

The `:alpine` image still requires the `py3-openssl` to run `gsutil signurl` somehow.