### PR TITLE
Unify Debian based Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,11 @@ FROM docker:24.0.6 as static-docker-source
 FROM debian:bullseye
 ARG CLOUD_SDK_VERSION
 ENV CLOUD_SDK_VERSION=$CLOUD_SDK_VERSION
-ENV PATH "$PATH:/opt/google-cloud-sdk/bin/"
 COPY --from=static-docker-source /usr/local/bin/docker /usr/local/bin/docker
 COPY --from=static-docker-source /usr/local/libexec/docker/cli-plugins/docker-buildx /usr/local/libexec/docker/cli-plugins/docker-buildx
 RUN groupadd -r -g 1000 cloudsdk && \
     useradd -r -u 1000 -m -s /bin/bash -g cloudsdk cloudsdk
-RUN apt-get -qqy update && apt-get -qqy upgrade && apt-get install -qqy \
+RUN apt-get update -qqy && apt-get -qqy upgrade && apt-get install -qqy \
         curl \
         python3-dev \
         python3-crcmod \
@@ -19,8 +18,8 @@ RUN apt-get -qqy update && apt-get -qqy upgrade && apt-get install -qqy \
         make \
         gnupg && \
     export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)" && \
-    echo "deb https://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" > /etc/apt/sources.list.d/google-cloud-sdk.list && \
-    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
+    echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" > /etc/apt/sources.list.d/google-cloud-sdk.list && \
+    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | tee /usr/share/keyrings/cloud.google.gpg && \
     apt-get update && \
     apt-get install -y google-cloud-cli=${CLOUD_SDK_VERSION}-0 \
         google-cloud-cli-app-engine-python=${CLOUD_SDK_VERSION}-0 \

--- a/debian_component_based/Dockerfile
+++ b/debian_component_based/Dockerfile
@@ -8,7 +8,7 @@ COPY --from=static-docker-source /usr/local/bin/docker /usr/local/bin/docker
 COPY --from=static-docker-source /usr/local/libexec/docker/cli-plugins/docker-buildx /usr/local/libexec/docker/cli-plugins/docker-buildx
 RUN groupadd -r -g 1000 cloudsdk && \
     useradd -r -u 1000 -m -s /bin/bash -g cloudsdk cloudsdk
-RUN apt-get -qqy update && apt-get -qqy upgrade && apt-get install -qqy \
+RUN apt-get update -qqy && apt-get -qqy upgrade && apt-get install -qqy \
         curl \
         gcc \
         python3-dev \

--- a/debian_slim/Dockerfile
+++ b/debian_slim/Dockerfile
@@ -3,7 +3,6 @@ FROM docker:24.0.6 as static-docker-source
 FROM debian:bullseye-slim
 ARG CLOUD_SDK_VERSION
 ENV CLOUD_SDK_VERSION=$CLOUD_SDK_VERSION
-ENV PATH "$PATH:/opt/google-cloud-sdk/bin/"
 COPY --from=static-docker-source /usr/local/bin/docker /usr/local/bin/docker
 COPY --from=static-docker-source /usr/local/libexec/docker/cli-plugins/docker-buildx /usr/local/libexec/docker/cli-plugins/docker-buildx
 RUN groupadd -r -g 1000 cloudsdk && \
@@ -14,22 +13,21 @@ RUN apt-get update -qqy && apt-get -qqy upgrade && apt-get install -qqy \
         curl \
         gcc \
         python3-dev \
+        python3-crcmod \
         python3-pip \
         apt-transport-https \
         lsb-release \
         openssh-client \
         git \
         gnupg && \
-    pip3 install -U crcmod && \
     export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)" && \
-    echo "deb https://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" > /etc/apt/sources.list.d/google-cloud-sdk.list && \
-    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
+    echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" > /etc/apt/sources.list.d/google-cloud-sdk.list && \
+    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | tee /usr/share/keyrings/cloud.google.gpg && \
     apt-get update && apt-get install -y google-cloud-cli=${CLOUD_SDK_VERSION}-0 $INSTALL_COMPONENTS && \
     gcloud config set core/disable_usage_reporting true && \
     gcloud config set component_manager/disable_update_check true && \
     gcloud config set metrics/environment github_docker_image && \
-    gcloud --version
-
+    gcloud --version && \
+    docker --version
 RUN git config --system credential.'https://source.developers.google.com'.helper gcloud.sh
-
 VOLUME ["/root/.config"]


### PR DESCRIPTION
Compared the Debian based Dockerfiles and unified the files somehow

1)  The path `/opt/google-cloud-sdk/` does not exist, remove `PATH` extension
2) `apt-key` is deprecated in Debian 11, switch to recommended way by docs https://cloud.google.com/sdk/docs/install-sdk#deb
3) Switch to `python3-crcmod` deb package in `:slim` image (already in `:latest` by 2e81e4a496b9aa8940157ce52212b5371864a82e)
4) minor changes