### PR TITLE
Update static docker source to v20.10.25

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker:20.10.24 as static-docker-source
+FROM docker:20.10.25 as static-docker-source
 
 FROM debian:bullseye
 ARG CLOUD_SDK_VERSION

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker:20.10.24 as static-docker-source
+FROM docker:20.10.25 as static-docker-source
 
 FROM alpine:3.17
 ARG CLOUD_SDK_VERSION

--- a/debian_component_based/Dockerfile
+++ b/debian_component_based/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker:20.10.24 as static-docker-source
+FROM docker:20.10.25 as static-docker-source
 
 FROM debian:bullseye
 ARG CLOUD_SDK_VERSION

--- a/debian_slim/Dockerfile
+++ b/debian_slim/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker:20.10.24 as static-docker-source
+FROM docker:20.10.25 as static-docker-source
 
 FROM debian:bullseye-slim
 ARG CLOUD_SDK_VERSION


### PR DESCRIPTION
The latest docker release contains several security fixes (in Packaging Updates).

https://github.com/moby/moby/releases/tag/v20.10.25
