### PR TITLE
Update static docker source to v23.0.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker:20.10.25 as static-docker-source
+FROM docker:23.0.6 as static-docker-source
 
 FROM debian:bullseye
 ARG CLOUD_SDK_VERSION

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker:20.10.25 as static-docker-source
+FROM docker:23.0.6 as static-docker-source
 
 FROM alpine:3.17
 ARG CLOUD_SDK_VERSION

--- a/debian_component_based/Dockerfile
+++ b/debian_component_based/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker:20.10.25 as static-docker-source
+FROM docker:23.0.6 as static-docker-source
 
 FROM debian:bullseye
 ARG CLOUD_SDK_VERSION

--- a/debian_slim/Dockerfile
+++ b/debian_slim/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker:20.10.25 as static-docker-source
+FROM docker:23.0.6 as static-docker-source
 
 FROM debian:bullseye-slim
 ARG CLOUD_SDK_VERSION


### PR DESCRIPTION
There is a mistake in my pull request #326 the Docker image `docker:20.10.25` will not be available. It seems they stopped building and providing binary builds of the v20.10 branch https://github.com/docker-library/docker/pull/426

This pull request updates the Docker version to the latest release of v23.0

https://github.com/moby/moby/releases/tag/v23.0.6
https://github.com/moby/moby/releases/tag/v23.0.5
https://github.com/moby/moby/releases/tag/v23.0.4
https://github.com/moby/moby/releases/tag/v23.0.3
https://github.com/moby/moby/releases/tag/v23.0.2
https://github.com/moby/moby/releases/tag/v23.0.1
https://github.com/moby/moby/releases/tag/v23.0.0

I am not sure if the new Docker releases are compatible at all.