### PR TITLE
Add apk upgrade to Alpine based Docker image

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -9,7 +9,7 @@ COPY --from=static-docker-source /usr/local/libexec/docker/cli-plugins/docker-bu
 RUN addgroup -g 1000 -S cloudsdk && \
     adduser -u 1000 -S cloudsdk -G cloudsdk
 RUN if [ `uname -m` = 'x86_64' ]; then echo -n "x86_64" > /tmp/arch; else echo -n "arm" > /tmp/arch; fi;
-RUN ARCH=`cat /tmp/arch` && apk --no-cache add \
+RUN ARCH=`cat /tmp/arch` && apk --no-cache upgrade && apk --no-cache add \
         curl \
         python3 \
         py3-crcmod \


### PR DESCRIPTION
At the moment the `alpine:3.18` Docker image is not up 2 date. Missing some security updates e.g. for Openssl packages.

```
$ docker pull alpine:3.18 
3.18: Pulling from library/alpine
Digest: sha256:eece025e432126ce23f223450a0326fbebde39cdf496a85d8c016293fc851978
Status: Image is up to date for alpine:3.18
docker.io/library/alpine:3.18

$ docker run --rm -it alpine:3.18 
/ # apk --no-cache upgrade
fetch https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.18/community/x86_64/APKINDEX.tar.gz
(1/7) Upgrading musl (1.2.4-r1 -> 1.2.4-r2)
(2/7) Upgrading busybox (1.36.1-r2 -> 1.36.1-r5)
Executing busybox-1.36.1-r5.post-upgrade
(3/7) Upgrading busybox-binsh (1.36.1-r2 -> 1.36.1-r5)
(4/7) Upgrading libcrypto3 (3.1.3-r0 -> 3.1.4-r1)
(5/7) Upgrading libssl3 (3.1.3-r0 -> 3.1.4-r1)
(6/7) Upgrading ssl_client (1.36.1-r2 -> 1.36.1-r5)
(7/7) Upgrading musl-utils (1.2.4-r1 -> 1.2.4-r2)
Executing busybox-1.36.1-r5.trigger
OK: 7 MiB in 15 packages
```

As the Debian based images include an `apt update && apt upgrade` step, it might be good to add an upgrade step to the Alpine based image, too.