### PR TITLE
Use gcloud as a docker credential helper for all GCP registries.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,4 +42,5 @@ RUN apt-get install -qqy \
         gcc \
         python3-pip
 RUN git config --system credential.'https://source.developers.google.com'.helper gcloud.sh
+RUN gcloud auth configure-docker --quiet --include-artifact-registry
 VOLUME ["/root/.config", "/root/.kube"]

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -27,4 +27,5 @@ RUN ARCH=`cat /tmp/arch` && apk --no-cache upgrade && apk --no-cache add \
     gcloud config set metrics/environment github_docker_image && \
     gcloud --version
 RUN git config --system credential.'https://source.developers.google.com'.helper gcloud.sh
+RUN gcloud auth configure-docker --quiet --include-artifact-registry
 VOLUME ["/root/.config"]

--- a/debian_component_based/Dockerfile
+++ b/debian_component_based/Dockerfile
@@ -31,4 +31,5 @@ RUN if [ `uname -m` = 'x86_64' ]; then echo -n " appctl nomos anthos-auth" >> /t
 RUN /google-cloud-sdk/install.sh --bash-completion=false --path-update=true --usage-reporting=false \
 	--additional-components `cat /tmp/additional_components` && rm -rf /google-cloud-sdk/.install/.backup
 RUN git config --system credential.'https://source.developers.google.com'.helper gcloud.sh
+RUN gcloud auth configure-docker --quiet --include-artifact-registry
 VOLUME ["/root/.config", "/root/.kube"]

--- a/debian_slim/Dockerfile
+++ b/debian_slim/Dockerfile
@@ -30,4 +30,5 @@ RUN apt-get update -qqy && apt-get -qqy upgrade && apt-get install -qqy \
     gcloud --version && \
     docker --version
 RUN git config --system credential.'https://source.developers.google.com'.helper gcloud.sh
+RUN gcloud auth configure-docker --quiet --include-artifact-registry
 VOLUME ["/root/.config"]


### PR DESCRIPTION
This will make the image a bit easier to use in CI where docker auth is required. However, there is a warning that having a long credential helper list (like would be added from this change) introduces slowness in `docker build` commands. I believe this is because docker will [fetch the credentials for each registry](https://github.com/docker/cli/blob/master/cli/config/configfile/file.go#L303) in the config file before the build itself. An alternative would be to use the standalone credential helper, but it's [not available as a gcloud component](https://cloud.google.com/sdk/docs/components#external_package_managers).