### PR TITLE
Release stable image as default image for gcloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The full repository name for Container Registry is `gcr.io/google.com/cloudsdkto
 
 ## Supported tags
 
-* `:stable`, `:VERSION-stable`: (default image with the basic version of gcloud without any pre-installed components, Debian-based)
+* `:stable`, `:VERSION-stable`: (default image with a standard gcloud installation, Debian-based)
 * `:latest`, `:VERSION`: (large image with
   additional components pre-installed, Debian-based)
 * `:slim`,  `:VERSION-slim`: (smaller image with

--- a/README.md
+++ b/README.md
@@ -2,9 +2,8 @@
 
 The Google Cloud CLI Docker Images (comprising the `:latest`, `:slim`, `:alpine`, `:emulators`, and `:debian_component_based` images located within this repository) are a set of images enabling the usage of the Google Cloud CLI as well as its bundled components.
 
-The `:latest` tag is Debian-based and includes default command
-line tools of Google Cloud CLI (`gcloud`, `gsutil`, `bq`) as well several 
-[additional components](https://cloud.google.com/sdk/docs/install#deb).
+The `:stable` tag is Debian-based and includes default command
+line tools of Google Cloud CLI (`gcloud`, `gsutil`, `bq`).
 
 ## Repositories
 The Google Cloud CLI Docker Image is hosted on [Container Registry](https://gcr.io/google.com/cloudsdktool/google-cloud-cli).
@@ -13,6 +12,7 @@ The full repository name for Container Registry is `gcr.io/google.com/cloudsdkto
 
 ## Supported tags
 
+* `:stable`, `:VERSION-stable`: (default image with the basic version of gcloud without any pre-installed components, Debian-based)
 * `:latest`, `:VERSION`: (large image with
   additional components pre-installed, Debian-based)
 * `:slim`,  `:VERSION-slim`: (smaller image with
@@ -30,20 +30,20 @@ The full repository name for Container Registry is `gcr.io/google.com/cloudsdkto
 To use this image, pull from [Container Registry](https://gcr.io/google.com/cloudsdktool/google-cloud-cli) and then run the following command:
 
 ```
-docker pull gcr.io/google.com/cloudsdktool/google-cloud-cli:latest
+docker pull gcr.io/google.com/cloudsdktool/google-cloud-cli:stable
 ```
 
 Verify the install
 
 ```bash
-docker run gcr.io/google.com/cloudsdktool/google-cloud-cli:latest gcloud version
-Google Cloud CLI 368.0.0
+docker run gcr.io/google.com/cloudsdktool/google-cloud-cli:stable gcloud version
+Google Cloud CLI 485.0.0
 ```
 
-or use a particular version number:
+or use a particular version number (485.0.0 or greater for `:stable`):
 
 ```bash
-docker run gcr.io/google.com/cloudsdktool/google-cloud-cli:368.0.0 gcloud version
+docker run gcr.io/google.com/cloudsdktool/google-cloud-cli:stable-485.0.0 gcloud version
 ```
 
 You can authenticate `gcloud` with your user credentials by running [`gcloud auth login`](https://cloud.google.com/sdk/gcloud/reference/auth/login):
@@ -160,9 +160,16 @@ You can set any Cloud SDK property via an ENV,
 #### Debian-based images
 
 ```
+cd stable/
+docker build --build-arg CLOUD_SDK_VERSION=485.0.0 \
+    --build-arg INSTALL_COMPONENTS="google-cloud-cli-datastore-emulator=485.0.0-0" \
+    -t my-cloud-sdk-docker:stable .
+```
+
+```
 cd debian_slim/
-docker build --build-arg CLOUD_SDK_VERSION=382.0.0 \
-    --build-arg INSTALL_COMPONENTS="google-cloud-cli-datastore-emulator=382.0.0-0" \
+docker build --build-arg CLOUD_SDK_VERSION=485.0.0 \
+    --build-arg INSTALL_COMPONENTS="google-cloud-cli-datastore-emulator=485.0.0-0" \
     -t my-cloud-sdk-docker:slim .
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Google Cloud CLI Docker
 
-The Google Cloud CLI Docker Images (comprising the `:latest`, `:slim`, `:alpine`, `:emulators`, and `:debian_component_based` images located within this repository) are a set of images enabling the usage of the Google Cloud CLI as well as its bundled components.
+The Google Cloud CLI Docker Images (comprising the `:stable`, `:latest`, `:slim`, `:alpine`, `:emulators`, and `:debian_component_based` images located within this repository) are a set of images enabling the usage of the Google Cloud CLI as well as its bundled components.
 
 The `:stable` tag is Debian-based and includes default command
-line tools of Google Cloud CLI (`gcloud`, `gsutil`, `bq`).
+line tools of Google Cloud CLI (`gcloud`, `gsutil`, `bq`). [Additional components](https://cloud.google.com/sdk/docs/install#deb) can also be installed using the INSTALL_COMPONENTS build argument.
 
 ## Repositories
 The Google Cloud CLI Docker Image is hosted on [Container Registry](https://gcr.io/google.com/cloudsdktool/google-cloud-cli).

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -53,7 +53,7 @@ steps:
   waitFor: ['-']
 - name: 'gcr.io/cloud-builders/docker'
   id: stable
-  args: ['build', '--build-arg', 'CLOUD_SDK_VERSION=$_CLI_VERSION', '-t', 'google/cloud-sdk:stable-alpha', '-t', 'google/cloud-sdk:$TAG_NAME-stable-alpha', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:stable-alpha', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:$TAG_NAME-stable-alpha', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:stable-alpha', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:$TAG_NAME-stable-alpha', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:stable-alpha', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:$TAG_NAME-stable-alpha', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:stable-alpha', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:$TAG_NAME-stable-alpha', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:stable-alpha', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:$TAG_NAME-stable-alpha', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:stable-alpha', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:$TAG_NAME-stable-alpha', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:stable-alpha', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:$TAG_NAME-stable-alpha', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:stable-alpha', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:$TAG_NAME-stable-alpha', 'stable/']
+  args: ['build', '--build-arg', 'CLOUD_SDK_VERSION=$_CLI_VERSION', '-t', 'google/cloud-sdk:stable', '-t', 'google/cloud-sdk:$TAG_NAME-stable', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:stable', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:$TAG_NAME-stable', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:stable', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:$TAG_NAME-stable', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:stable', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:$TAG_NAME-stable', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:stable', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:$TAG_NAME-stable', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:stable', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:$TAG_NAME-stable', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:stable', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:$TAG_NAME-stable', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:stable', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:$TAG_NAME-stable', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:stable', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:$TAG_NAME-stable', 'stable/']
   waitFor: ['-']
 # END OF PROD BUILDING STEPS
 - name: 'gcr.io/cloud-builders/docker'
@@ -108,10 +108,10 @@ steps:
   args: ['push', 'google/cloud-sdk:$TAG_NAME-emulators']
   waitFor: ['dockersecret', 'emulators']
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['push', 'google/cloud-sdk:stable-alpha']
+  args: ['push', 'google/cloud-sdk:stable']
   waitFor: ['dockersecret', 'stable']
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['push', 'google/cloud-sdk:$TAG_NAME-stable-alpha']
+  args: ['push', 'google/cloud-sdk:$TAG_NAME-stable']
   waitFor: ['dockersecret', 'stable']
 images:
 - 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:$TAG_NAME'
@@ -119,65 +119,65 @@ images:
 - 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:$TAG_NAME-debian_component_based'
 - 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:$TAG_NAME-emulators'
 - 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:$TAG_NAME-slim'
-- 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:$TAG_NAME-stable-alpha'
+- 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:$TAG_NAME-stable'
 - 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:alpine'
 - 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:debian_component_based'
 - 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:emulators'
 - 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:latest'
 - 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:slim'
-- 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:stable-alpha'
+- 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:stable'
 - 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:$TAG_NAME'
-- 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:$TAG_NAME-stable-alpha'
+- 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:$TAG_NAME-stable'
 - 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:latest'
-- 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:stable-alpha'
+- 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:stable'
 - 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:$TAG_NAME'
 - 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:$TAG_NAME-alpine'
 - 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:$TAG_NAME-debian_component_based'
 - 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:$TAG_NAME-emulators'
 - 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:$TAG_NAME-slim'
-- 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:$TAG_NAME-stable-alpha'
+- 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:$TAG_NAME-stable'
 - 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:alpine'
 - 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:debian_component_based'
 - 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:emulators'
 - 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:latest'
 - 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:slim'
-- 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:stable-alpha'
+- 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:stable'
 - 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:$TAG_NAME'
-- 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:$TAG_NAME-stable-alpha'
+- 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:$TAG_NAME-stable'
 - 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:latest'
-- 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:stable-alpha'
+- 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:stable'
 - 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:$TAG_NAME'
 - 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:$TAG_NAME-alpine'
 - 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:$TAG_NAME-debian_component_based'
 - 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:$TAG_NAME-emulators'
 - 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:$TAG_NAME-slim'
-- 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:$TAG_NAME-stable-alpha'
+- 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:$TAG_NAME-stable'
 - 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:alpine'
 - 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:debian_component_based'
 - 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:emulators'
 - 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:latest'
 - 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:slim'
-- 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:stable-alpha'
+- 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:stable'
 - 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:$TAG_NAME'
-- 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:$TAG_NAME-stable-alpha'
+- 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:$TAG_NAME-stable'
 - 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:latest'
-- 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:stable-alpha'
+- 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:stable'
 - 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:$TAG_NAME'
 - 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:$TAG_NAME-alpine'
 - 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:$TAG_NAME-debian_component_based'
 - 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:$TAG_NAME-emulators'
 - 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:$TAG_NAME-slim'
-- 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:$TAG_NAME-stable-alpha'
+- 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:$TAG_NAME-stable'
 - 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:alpine'
 - 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:debian_component_based'
 - 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:emulators'
 - 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:latest'
 - 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:slim'
-- 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:stable-alpha'
+- 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:stable'
 - 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:$TAG_NAME'
-- 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:$TAG_NAME-stable-alpha'
+- 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:$TAG_NAME-stable'
 - 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:latest'
-- 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:stable-alpha'
+- 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:stable'
 secrets:
 - kmsKeyName: projects/google.com:cloudsdktool/locations/global/keyRings/docker/cryptoKeys/dockerhub-password
   secretEnv:

--- a/generate_cloudbuild.py
+++ b/generate_cloudbuild.py
@@ -63,7 +63,7 @@ LABEL_FOR_IMAGE={
     'default': '',
     'debian_component_based': 'debian_component_based',
     'emulators': 'emulators',
-    'stable': 'stable-alpha'  # change it to stable when the image is ready to release.
+    'stable': 'stable'  # change it to stable when the image is ready to release.
     }
 
 def MakeGcrTags(label_without_tag,

--- a/stable/Dockerfile
+++ b/stable/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update -qqy && apt-get -qqy upgrade && \
     echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
     curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && \
     apt-get update && \
-    apt-get install -y google-cloud-cli=${CLOUD_SDK_VERSION}-0 $INSTALL_COMPONENTS &&\
+    apt-get install -y --no-install-recommends google-cloud-cli=${CLOUD_SDK_VERSION}-0 $INSTALL_COMPONENTS &&\
     rm -rf /root/.cache/pip/ && \
     find / -name '*.pyc' -delete && \
     find / -name '*__pycache__*' -delete
@@ -32,7 +32,7 @@ RUN if [ `uname -m` = 'x86_64' ]; then echo -n "x86_64" > /tmp/arch; else echo -
 RUN gcloud --version && \
     gcloud config set core/disable_usage_reporting false && \
     gcloud config set component_manager/disable_update_check true && \
-    gcloud config set metrics/environment docker_image_stable_alpha && \
+    gcloud config set metrics/environment docker_image_stable && \
     rm -rf /root/.cache/pip/ && \
     find / -name '*.pyc' -delete && \
     find / -name '*__pycache__*' -exec rm -r {} \+


### PR DESCRIPTION
Release new `:stable` docker image for gcloud cli. This is going to be the default docker image going forward.