### PR TITLE
Alpine upgrade

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,6 +1,6 @@
 FROM docker:27.3.1 as static-docker-source
 
-FROM alpine:3.19
+FROM alpine:3.20
 ARG CLOUD_SDK_VERSION
 ENV CLOUD_SDK_VERSION=$CLOUD_SDK_VERSION
 ENV PATH /google-cloud-sdk/bin:$PATH
@@ -9,16 +9,40 @@ COPY --from=static-docker-source /usr/local/libexec/docker/cli-plugins/docker-bu
 RUN addgroup -g 1000 -S cloudsdk && \
     adduser -u 1000 -S cloudsdk -G cloudsdk
 RUN if [ `uname -m` = 'x86_64' ]; then echo -n "x86_64" > /tmp/arch; else echo -n "arm" > /tmp/arch; fi;
-RUN ARCH=`cat /tmp/arch` && apk --no-cache upgrade && apk --no-cache add \
+# install python 3.11
+RUN apk --no-cache upgrade && apk --no-cache add \
         curl \
-        python3 \
+    	openssl-dev \
+     	zlib-dev \
+    	gcc \
+   	g++ \
+	make \
+    && curl -O https://www.python.org/ftp/python/3.11.9/Python-3.11.9.tgz \
+    && tar -xzf Python-3.11.9.tgz \
+    && cd Python-3.11.9	\
+    && ./configure --enable-optimizations \
+    && make -j$(nproc) \
+    && make altinstall \
+    # && python3 --version \	
+    && python3.11 --version \
+    && which python3.11 \
+    && rm -rf Python-3.11.9 \
+    && rm -rf Python-3.11.9.tgz
+
+RUN apk --no-cache upgrade && apk --no-cache del \
+	openssl-dev \
+	zlib-dev \
+	gcc \
+	g++ \
+	make \
+    && apk cache clean 
+RUN ARCH=`cat /tmp/arch` && apk --no-cache upgrade && apk --no-cache add \
         py3-crcmod \
         py3-openssl \
         bash \
         libc6-compat \
         openssh-client \
         git \
-        gnupg \
     && curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-${CLOUD_SDK_VERSION}-linux-${ARCH}.tar.gz && \
     tar xzf google-cloud-cli-${CLOUD_SDK_VERSION}-linux-${ARCH}.tar.gz && \
     rm google-cloud-cli-${CLOUD_SDK_VERSION}-linux-${ARCH}.tar.gz && \
@@ -28,3 +52,4 @@ RUN ARCH=`cat /tmp/arch` && apk --no-cache upgrade && apk --no-cache add \
     gcloud --version
 RUN git config --system credential.'https://source.developers.google.com'.helper gcloud.sh
 VOLUME ["/root/.config"]
+

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,14 +1,6 @@
 FROM docker:27.3.1 as static-docker-source
 
-FROM alpine:3.20
-ARG CLOUD_SDK_VERSION
-ENV CLOUD_SDK_VERSION=$CLOUD_SDK_VERSION
-ENV PATH /google-cloud-sdk/bin:$PATH
-COPY --from=static-docker-source /usr/local/bin/docker /usr/local/bin/docker
-COPY --from=static-docker-source /usr/local/libexec/docker/cli-plugins/docker-buildx /usr/local/libexec/docker/cli-plugins/docker-buildx
-RUN addgroup -g 1000 -S cloudsdk && \
-    adduser -u 1000 -S cloudsdk -G cloudsdk
-RUN if [ `uname -m` = 'x86_64' ]; then echo -n "x86_64" > /tmp/arch; else echo -n "arm" > /tmp/arch; fi;
+FROM alpine:3.20 as build_image
 # install python 3.11
 RUN apk --no-cache upgrade && apk --no-cache add \
         curl \
@@ -20,6 +12,7 @@ RUN apk --no-cache upgrade && apk --no-cache add \
         sqlite-dev \ 
         readline-dev \
 	libffi-dev \
+    &&  rm -rf /var/cache/apk/* \	
     && curl -O https://www.python.org/ftp/python/3.11.9/Python-3.11.9.tgz \
     && tar -xzf Python-3.11.9.tgz \
     && cd Python-3.11.9 \
@@ -36,13 +29,30 @@ RUN python3 --version && \
     python3 -m pip install crcmod && \
     # apk add --no-cache musl-dev rust cargo && \
     python3 -m pip install pyOpenSSL && \
-    python3 -m pip install cryptography
+    python3 -m pip install cryptography && \
+    rm -rf /root/.cache/pip && \
+    find / -name '*.pyc' -delete && \
+    find / -name '*__pycache__*' -exec rm -r {} \+
+
+FROM alpine:3.20 
+ARG CLOUD_SDK_VERSION
+ENV CLOUD_SDK_VERSION=$CLOUD_SDK_VERSION
+ENV PATH /google-cloud-sdk/bin:$PATH
+COPY --from=static-docker-source /usr/local/bin/docker /usr/local/bin/docker
+COPY --from=static-docker-source /usr/local/libexec/docker/cli-plugins/docker-buildx /usr/local/libexec/docker/cli-plugins/docker-buildx
+COPY --from=build_image /usr/local/lib/python3.11 /usr/local/lib/python3.11
+COPY --from=build_image /usr/bin/python3 /usr/bin/python3
+RUN addgroup -g 1000 -S cloudsdk && \
+    adduser -u 1000 -S cloudsdk -G cloudsdk
+RUN if [ `uname -m` = 'x86_64' ]; then echo -n "x86_64" > /tmp/arch; else echo -n "arm" > /tmp/arch; fi;
 RUN export CLOUDSDK_PYTHON=/usr/local/bin/python3.11
 RUN ARCH=`cat /tmp/arch` && apk --no-cache upgrade && apk --no-cache add \
-        bash \
+        curl \
+	bash \
         libc6-compat \
         openssh-client \
         git \
+	gnupg \
     && curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-${CLOUD_SDK_VERSION}-linux-${ARCH}.tar.gz && \
     tar xzf google-cloud-cli-${CLOUD_SDK_VERSION}-linux-${ARCH}.tar.gz && \
     rm google-cloud-cli-${CLOUD_SDK_VERSION}-linux-${ARCH}.tar.gz && \
@@ -50,8 +60,11 @@ RUN ARCH=`cat /tmp/arch` && apk --no-cache upgrade && apk --no-cache add \
     gcloud config set component_manager/disable_update_check true && \
     gcloud config set metrics/environment docker_image_alpine && \
     gcloud --version && \
-    python3 --version 
+    rm -rf /root/.cache/pip && \
+    find / -name '*.pyc' -delete && \
+    find / -name '*__pycache__*' -exec rm -r {} \+ 
     #python3.12 --version 	
+    
 RUN git config --system credential.'https://source.developers.google.com'.helper gcloud.sh
 VOLUME ["/root/.config"]
 

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -12,33 +12,33 @@ RUN if [ `uname -m` = 'x86_64' ]; then echo -n "x86_64" > /tmp/arch; else echo -
 # install python 3.11
 RUN apk --no-cache upgrade && apk --no-cache add \
         curl \
-    	openssl-dev \
-     	zlib-dev \
-    	gcc \
-   	g++ \
-	make \
+        openssl-dev \
+        zlib-dev \
+        gcc \
+        g++ \
+        make \
+        sqlite-dev \ 
+        readline-dev \
+	libffi-dev \
     && curl -O https://www.python.org/ftp/python/3.11.9/Python-3.11.9.tgz \
     && tar -xzf Python-3.11.9.tgz \
-    && cd Python-3.11.9	\
+    && cd Python-3.11.9 \
     && ./configure --enable-optimizations \
     && make -j$(nproc) \
     && make altinstall \
-    # && python3 --version \	
+    # && python3 --version \    
     && python3.11 --version \
-    && which python3.11 \
+    && ln -sf /usr/local/bin/python3.11 /usr/bin/python3 \
     && rm -rf Python-3.11.9 \
-    && rm -rf Python-3.11.9.tgz
-
-RUN apk --no-cache upgrade && apk --no-cache del \
-	openssl-dev \
-	zlib-dev \
-	gcc \
-	g++ \
-	make \
-    && apk cache clean 
+    && rm -rf Python-3.11.9.tgz 
+RUN python3 --version && \
+    python3 -m ensurepip --upgrade && \
+    python3 -m pip install crcmod && \
+    # apk add --no-cache musl-dev rust cargo && \
+    python3 -m pip install pyOpenSSL && \
+    python3 -m pip install cryptography
+RUN export CLOUDSDK_PYTHON=/usr/local/bin/python3.11
 RUN ARCH=`cat /tmp/arch` && apk --no-cache upgrade && apk --no-cache add \
-        py3-crcmod \
-        py3-openssl \
         bash \
         libc6-compat \
         openssh-client \
@@ -49,7 +49,9 @@ RUN ARCH=`cat /tmp/arch` && apk --no-cache upgrade && apk --no-cache add \
     gcloud config set core/disable_usage_reporting true && \
     gcloud config set component_manager/disable_update_check true && \
     gcloud config set metrics/environment docker_image_alpine && \
-    gcloud --version
+    gcloud --version && \
+    python3 --version 
+    #python3.12 --version 	
 RUN git config --system credential.'https://source.developers.google.com'.helper gcloud.sh
 VOLUME ["/root/.config"]
 


### PR DESCRIPTION
Upgrade the alpine image to version 3.20 while keeping the python version 3.11.9. 

This was done because:
* the default python version for 3.20 is python 3.12
* `gsutil` component is not yet fully compatible with python 3.12