### PR TITLE
Fix `find` including nonexistent files when cleaning up .pyc files.

### DIFF
--- a/stable/Dockerfile
+++ b/stable/Dockerfile
@@ -16,8 +16,8 @@ RUN apt-get update -qqy && apt-get -qqy upgrade && \
     apt-get update && \
     apt-get install -y --no-install-recommends google-cloud-cli=${CLOUD_SDK_VERSION}-0 $INSTALL_COMPONENTS &&\
     rm -rf /root/.cache/pip/ && \
-    find / -name '*.pyc' -delete && \
-    find / -name '*__pycache__*' -delete
+    find /usr/lib/google-cloud-sdk -name '*.pyc' -delete && \
+    find /usr/lib/google-cloud-sdk -name '*__pycache__*' -delete
 FROM marketplace.gcr.io/google/debian12:latest as runtime_image
 COPY --from=build_image /usr/lib/google-cloud-sdk /usr/lib/google-cloud-sdk
 
@@ -34,8 +34,8 @@ RUN gcloud --version && \
     gcloud config set component_manager/disable_update_check true && \
     gcloud config set metrics/environment docker_image_stable && \
     rm -rf /root/.cache/pip/ && \
-    find / -name '*.pyc' -delete && \
-    find / -name '*__pycache__*' -exec rm -r {} \+
+    find /usr/lib/google-cloud-sdk -name '*.pyc' -delete && \
+    find /usr/lib/google-cloud-sdk -name '*__pycache__*' -exec rm -r {} \+
 VOLUME ["/root/.config"]
 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh


### PR DESCRIPTION
This step sometimes results in a build failure e.g.:

find: '/proc/44': No such file or directory

This can happen if the find results include /proc/<PID> files for processes that have finished between the time when `find` reads the name of the file in the directory and when it goes to stat the file (see -ignore_readdir_race in `man find`).

In our case, all the pycache dirs and .pyc files come from the /usr/lib/google-cloud-sdk directory, so we can just restrict the search to there instead of the root directory.