### PR TITLE
Remove docker-buildx from alpine and debian_component_based image

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -5,7 +5,6 @@ ARG CLOUD_SDK_VERSION
 ENV CLOUD_SDK_VERSION=$CLOUD_SDK_VERSION
 ENV PATH /google-cloud-sdk/bin:$PATH
 COPY --from=static-docker-source /usr/local/bin/docker /usr/local/bin/docker
-COPY --from=static-docker-source /usr/local/libexec/docker/cli-plugins/docker-buildx /usr/local/libexec/docker/cli-plugins/docker-buildx
 RUN addgroup -g 1000 -S cloudsdk && \
     adduser -u 1000 -S cloudsdk -G cloudsdk
 RUN if [ `uname -m` = 'x86_64' ]; then echo -n "x86_64" > /tmp/arch; else echo -n "arm" > /tmp/arch; fi;

--- a/debian_component_based/Dockerfile
+++ b/debian_component_based/Dockerfile
@@ -5,7 +5,6 @@ ARG CLOUD_SDK_VERSION
 ENV CLOUD_SDK_VERSION=$CLOUD_SDK_VERSION
 ENV PATH /google-cloud-sdk/bin:$PATH
 COPY --from=static-docker-source /usr/local/bin/docker /usr/local/bin/docker
-COPY --from=static-docker-source /usr/local/libexec/docker/cli-plugins/docker-buildx /usr/local/libexec/docker/cli-plugins/docker-buildx
 RUN groupadd -r -g 1000 cloudsdk && \
     useradd -r -u 1000 -m -s /bin/bash -g cloudsdk cloudsdk
 RUN apt-get update -qqy && apt-get -qqy upgrade && apt-get install -qqy \


### PR DESCRIPTION
This change should not be submitted before the next gcloud release 518.0.0 (scheduled on April 15, 2025). The documentation update ([devsite](https://cloud.google.com/sdk/docs/downloads-docker#whats_new_important_updates)) is completed and we should release the new gcloud images (`:alpha` abd `:debian_component_based`) in the next release v519.0.0.  

bug: [b/394287492](https://b.corp.google.com/issues/394287492)