### PR TITLE
Consume debian base image from airlock for `:latest` image. 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM docker:28.1.1 as static-docker-source
 
-FROM marketplace.gcr.io/google/debian12:latest
+FROM us-docker.pkg.dev/artifact-foundry-prod/docker-3p-trusted/debian:12
 ARG CLOUD_SDK_VERSION
 ENV CLOUD_SDK_VERSION=$CLOUD_SDK_VERSION
 COPY --from=static-docker-source /usr/local/bin/docker /usr/local/bin/docker


### PR DESCRIPTION
Consume debian base image from airlock for `:latest` image.  Tested with cl/740471003 ([sponge link](https://fusion2.corp.google.com/invocations/9e82f963-f4f8-4f1b-a674-e64b7d9dc58c)).