### PR TITLE
Consume debian base image from airlock for `:emulators` image.

### DIFF
--- a/emulators/Dockerfile
+++ b/emulators/Dockerfile
@@ -1,5 +1,5 @@
 # debian12 is used instead of alpine because the cloud bigtable emulator requires glibc.
-FROM marketplace.gcr.io/google/debian12:latest
+FROM us-docker.pkg.dev/artifact-foundry-prod/docker-3p-trusted/debian:12 
 
 ARG CLOUD_SDK_VERSION
 ENV CLOUD_SDK_VERSION=$CLOUD_SDK_VERSION


### PR DESCRIPTION
Consume debian base image from airlock for `:emulators` image. Tested with cl/740471003 ([sponge link](https://fusion2.corp.google.com/invocations/9e82f963-f4f8-4f1b-a674-e64b7d9dc58c)).