### PR TITLE
Consume debian base image from airlock for `:stable` image.

### DIFF
--- a/stable/Dockerfile
+++ b/stable/Dockerfile
@@ -1,4 +1,4 @@
-FROM marketplace.gcr.io/google/debian12:latest as build_image
+FROM us-docker.pkg.dev/artifact-foundry-prod/docker-3p-trusted/debian:12 as build_image
 
 ARG CLOUD_SDK_VERSION
 ENV CLOUD_SDK_VERSION=$CLOUD_SDK_VERSION
@@ -18,7 +18,7 @@ RUN apt-get update -qqy && apt-get -qqy upgrade && \
     rm -rf /root/.cache/pip/ && \
     find /usr/lib/google-cloud-sdk -name '*.pyc' -delete && \
     find /usr/lib/google-cloud-sdk -name '*__pycache__*' -delete
-FROM marketplace.gcr.io/google/debian12:latest as runtime_image
+FROM us-docker.pkg.dev/artifact-foundry-prod/docker-3p-trusted/debian:12 as runtime_image
 COPY --from=build_image /usr/lib/google-cloud-sdk /usr/lib/google-cloud-sdk
 
 ENV PATH=$PATH:/usr/lib/google-cloud-sdk/bin


### PR DESCRIPTION
Consume debian base image from airlock for `:stable` image.  Tested with cl/740471003 ([sponge link](https://fusion2.corp.google.com/invocations/9e82f963-f4f8-4f1b-a674-e64b7d9dc58c)).