### PR TITLE
Consume alpine base image from airlock for `:alpine` image.

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,6 +1,6 @@
 FROM docker:28.1.1 as static-docker-source
 
-FROM alpine:3.20
+FROM us-docker.pkg.dev/artifact-foundry-prod/docker-3p-trusted/alpine:3.20
 ARG CLOUD_SDK_VERSION
 ENV CLOUD_SDK_VERSION=$CLOUD_SDK_VERSION
 ENV PATH /google-cloud-sdk/bin:$PATH


### PR DESCRIPTION
Consume alpine base image from airlock for `:alpine` image. Tested with cl/740471003 ([sponge_link](https://fusion2.corp.google.com/invocations/e2fb2c8d-2cc1-4acb-bb8a-4e5a85da81a1))