### PR TITLE
Add Arm support for the latest docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,8 @@ RUN if [ `uname -m` = 'x86_64' ]; then apt-get install -y google-cloud-cli-spann
 RUN apt-get install -qqy \
         gcc \
         python3-pip
-RUN gcloud config set core/disable_usage_reporting true && \
+RUN gcloud version && \ 
+    gcloud config set core/disable_usage_reporting true && \
     gcloud config set component_manager/disable_update_check true && \
     gcloud config set metrics/environment docker_image_latest 
 RUN git config --system credential.'https://source.developers.google.com'.helper gcloud.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,19 +30,17 @@ RUN apt-get update -qqy && apt-get -qqy upgrade && apt-get install -qqy \
         google-cloud-cli-pubsub-emulator=${CLOUD_SDK_VERSION}-0 \
         google-cloud-cli-bigtable-emulator=${CLOUD_SDK_VERSION}-0 \
         google-cloud-cli-firestore-emulator=${CLOUD_SDK_VERSION}-0 \
-        google-cloud-cli-spanner-emulator=${CLOUD_SDK_VERSION}-0 \
         google-cloud-cli-cbt=${CLOUD_SDK_VERSION}-0 \
         google-cloud-cli-kpt=${CLOUD_SDK_VERSION}-0 \
         google-cloud-cli-local-extract=${CLOUD_SDK_VERSION}-0 \
         google-cloud-cli-gke-gcloud-auth-plugin=${CLOUD_SDK_VERSION}-0 \
-        kubectl && \
-    gcloud config set core/disable_usage_reporting true && \
-    gcloud config set component_manager/disable_update_check true && \
-    gcloud config set metrics/environment docker_image_latest && \
-    gcloud --version && \
-    docker --version && kubectl version --client
+        kubectl 
+RUN if [ `uname -m` = 'x86_64' ]; then apt-get install -y google-cloud-cli-spanner-emulator=${CLOUD_SDK_VERSION}-0; fi;
 RUN apt-get install -qqy \
         gcc \
         python3-pip
+RUN gcloud config set core/disable_usage_reporting true && \
+    gcloud config set component_manager/disable_update_check true && \
+    gcloud config set metrics/environment docker_image_latest 
 RUN git config --system credential.'https://source.developers.google.com'.helper gcloud.sh
 VOLUME ["/root/.config", "/root/.kube"]

--- a/cloudbuild-hotfix.yaml
+++ b/cloudbuild-hotfix.yaml
@@ -1,3 +1,4 @@
+# IT IS A HOTFIX
 # PROD BUILDING STEPS
 options:
   logging: GCS_ONLY
@@ -37,52 +38,52 @@ steps:
   waitFor: ['-']
 - name: 'gcr.io/cloud-builders/docker'
   id: alpine
-  args: ['build', '--build-arg', 'CLOUD_SDK_VERSION=$_CLI_VERSION', '-t', 'google/cloud-sdk:alpine', '-t', 'google/cloud-sdk:$TAG_NAME-alpine', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:alpine', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:$TAG_NAME-alpine', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:$TAG_NAME-alpine-$_DATE', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:alpine', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:$TAG_NAME-alpine', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:$TAG_NAME-alpine-$_DATE', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:alpine', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:$TAG_NAME-alpine', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:$TAG_NAME-alpine-$_DATE', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:alpine', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:$TAG_NAME-alpine', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:$TAG_NAME-alpine-$_DATE', 'alpine/']
+  args: ['build', '--build-arg', 'CLOUD_SDK_VERSION=$_CLI_VERSION', '-t', 'google/cloud-sdk:alpine', '-t', 'google/cloud-sdk:$TAG_NAME-alpine-$_DATE', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:alpine', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:$TAG_NAME-alpine-$_DATE', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:alpine', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:$TAG_NAME-alpine-$_DATE', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:alpine', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:$TAG_NAME-alpine-$_DATE', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:alpine', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:$TAG_NAME-alpine-$_DATE', 'alpine/']
   waitFor: ['-']
 - name: 'gcr.io/cloud-builders/docker'
   id: debian_slim
-  args: ['build', '--build-arg', 'CLOUD_SDK_VERSION=$_CLI_VERSION', '-t', 'google/cloud-sdk:slim', '-t', 'google/cloud-sdk:$TAG_NAME-slim', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:slim', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:$TAG_NAME-slim', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:$TAG_NAME-slim-$_DATE', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:slim', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:$TAG_NAME-slim', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:$TAG_NAME-slim-$_DATE', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:slim', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:$TAG_NAME-slim', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:$TAG_NAME-slim-$_DATE', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:slim', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:$TAG_NAME-slim', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:$TAG_NAME-slim-$_DATE', 'debian_slim/']
+  args: ['build', '--build-arg', 'CLOUD_SDK_VERSION=$_CLI_VERSION', '-t', 'google/cloud-sdk:slim', '-t', 'google/cloud-sdk:$TAG_NAME-slim-$_DATE', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:slim', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:$TAG_NAME-slim-$_DATE', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:slim', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:$TAG_NAME-slim-$_DATE', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:slim', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:$TAG_NAME-slim-$_DATE', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:slim', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:$TAG_NAME-slim-$_DATE', 'debian_slim/']
   waitFor: ['-']
 - name: 'gcr.io/cloud-builders/docker'
   id: default
-  args: ['build', '--build-arg', 'CLOUD_SDK_VERSION=$_CLI_VERSION', '-t', 'google/cloud-sdk:latest', '-t', 'google/cloud-sdk:$TAG_NAME', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:latest', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:$TAG_NAME', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:$TAG_NAME-$_DATE', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:latest', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:$TAG_NAME', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:$TAG_NAME-$_DATE', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:latest', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:$TAG_NAME', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:$TAG_NAME-$_DATE', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:latest', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:$TAG_NAME', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:$TAG_NAME-$_DATE', '.']
+  args: ['build', '--build-arg', 'CLOUD_SDK_VERSION=$_CLI_VERSION', '-t', 'google/cloud-sdk:latest', '-t', 'google/cloud-sdk:$TAG_NAME-$_DATE', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:latest', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:$TAG_NAME-$_DATE', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:latest', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:$TAG_NAME-$_DATE', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:latest', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:$TAG_NAME-$_DATE', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:latest', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:$TAG_NAME-$_DATE', '.']
   waitFor: ['-']
 - name: 'gcr.io/cloud-builders/docker'
   id: debian_component_based
-  args: ['build', '--build-arg', 'CLOUD_SDK_VERSION=$_CLI_VERSION', '-t', 'google/cloud-sdk:debian_component_based', '-t', 'google/cloud-sdk:$TAG_NAME-debian_component_based', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:debian_component_based', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:$TAG_NAME-debian_component_based', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:$TAG_NAME-debian_component_based-$_DATE', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:debian_component_based', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:$TAG_NAME-debian_component_based', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:$TAG_NAME-debian_component_based-$_DATE', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:debian_component_based', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:$TAG_NAME-debian_component_based', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:$TAG_NAME-debian_component_based-$_DATE', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:debian_component_based', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:$TAG_NAME-debian_component_based', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:$TAG_NAME-debian_component_based-$_DATE', 'debian_component_based/']
+  args: ['build', '--build-arg', 'CLOUD_SDK_VERSION=$_CLI_VERSION', '-t', 'google/cloud-sdk:debian_component_based', '-t', 'google/cloud-sdk:$TAG_NAME-debian_component_based-$_DATE', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:debian_component_based', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:$TAG_NAME-debian_component_based-$_DATE', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:debian_component_based', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:$TAG_NAME-debian_component_based-$_DATE', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:debian_component_based', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:$TAG_NAME-debian_component_based-$_DATE', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:debian_component_based', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:$TAG_NAME-debian_component_based-$_DATE', 'debian_component_based/']
   waitFor: ['-']
 - name: 'gcr.io/cloud-builders/docker'
   id: emulators
-  args: ['build', '--build-arg', 'CLOUD_SDK_VERSION=$_CLI_VERSION', '-t', 'google/cloud-sdk:emulators', '-t', 'google/cloud-sdk:$TAG_NAME-emulators', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:emulators', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:$TAG_NAME-emulators', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:$TAG_NAME-emulators-$_DATE', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:emulators', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:$TAG_NAME-emulators', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:$TAG_NAME-emulators-$_DATE', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:emulators', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:$TAG_NAME-emulators', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:$TAG_NAME-emulators-$_DATE', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:emulators', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:$TAG_NAME-emulators', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:$TAG_NAME-emulators-$_DATE', 'emulators/']
+  args: ['build', '--build-arg', 'CLOUD_SDK_VERSION=$_CLI_VERSION', '-t', 'google/cloud-sdk:emulators', '-t', 'google/cloud-sdk:$TAG_NAME-emulators-$_DATE', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:emulators', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:$TAG_NAME-emulators-$_DATE', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:emulators', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:$TAG_NAME-emulators-$_DATE', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:emulators', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:$TAG_NAME-emulators-$_DATE', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:emulators', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:$TAG_NAME-emulators-$_DATE', 'emulators/']
   waitFor: ['-']
 - name: 'gcr.io/cloud-builders/docker'
   id: stable
-  args: ['build', '--build-arg', 'CLOUD_SDK_VERSION=$_CLI_VERSION', '-t', 'google/cloud-sdk:stable', '-t', 'google/cloud-sdk:$TAG_NAME-stable', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:stable', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:$TAG_NAME-stable', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:$TAG_NAME-stable-$_DATE', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:stable', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:$TAG_NAME-stable', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:$TAG_NAME-stable-$_DATE', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:stable', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:$TAG_NAME-stable', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:$TAG_NAME-stable-$_DATE', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:stable', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:$TAG_NAME-stable', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:$TAG_NAME-stable-$_DATE', 'stable/']
+  args: ['build', '--build-arg', 'CLOUD_SDK_VERSION=$_CLI_VERSION', '-t', 'google/cloud-sdk:stable', '-t', 'google/cloud-sdk:$TAG_NAME-stable-$_DATE', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:stable', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:$TAG_NAME-stable-$_DATE', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:stable', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:$TAG_NAME-stable-$_DATE', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:stable', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:$TAG_NAME-stable-$_DATE', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:stable', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:$TAG_NAME-stable-$_DATE', 'stable/']
   waitFor: ['-']
 # END OF PROD BUILDING STEPS
 - name: 'gcr.io/cloud-builders/docker'
   id: multi_arch_debian_slim
-  args: ['buildx', 'build', '--build-arg', 'CLOUD_SDK_VERSION=$_CLI_VERSION', '--platform', 'linux/arm64,linux/amd64', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:slim', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:$TAG_NAME-slim', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:$TAG_NAME-slim-$_DATE', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:slim', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:$TAG_NAME-slim', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:$TAG_NAME-slim-$_DATE', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:slim', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:$TAG_NAME-slim', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:$TAG_NAME-slim-$_DATE', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:slim', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:$TAG_NAME-slim', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:$TAG_NAME-slim-$_DATE', 'debian_slim/', '--push']
+  args: ['buildx', 'build', '--build-arg', 'CLOUD_SDK_VERSION=$_CLI_VERSION', '--platform', 'linux/arm64,linux/amd64', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:slim', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:$TAG_NAME-slim-$_DATE', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:slim', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:$TAG_NAME-slim-$_DATE', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:slim', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:$TAG_NAME-slim-$_DATE', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:slim', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:$TAG_NAME-slim-$_DATE', 'debian_slim/', '--push']
   waitFor: ['multi_arch_step3']
 - name: 'gcr.io/cloud-builders/docker'
   id: multi_arch_debian_component_based
-  args: ['buildx', 'build', '--build-arg', 'CLOUD_SDK_VERSION=$_CLI_VERSION', '--platform', 'linux/arm64,linux/amd64', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:debian_component_based', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:$TAG_NAME-debian_component_based', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:$TAG_NAME-debian_component_based-$_DATE', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:debian_component_based', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:$TAG_NAME-debian_component_based', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:$TAG_NAME-debian_component_based-$_DATE', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:debian_component_based', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:$TAG_NAME-debian_component_based', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:$TAG_NAME-debian_component_based-$_DATE', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:debian_component_based', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:$TAG_NAME-debian_component_based', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:$TAG_NAME-debian_component_based-$_DATE', 'debian_component_based/', '--push']
+  args: ['buildx', 'build', '--build-arg', 'CLOUD_SDK_VERSION=$_CLI_VERSION', '--platform', 'linux/arm64,linux/amd64', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:debian_component_based', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:$TAG_NAME-debian_component_based-$_DATE', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:debian_component_based', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:$TAG_NAME-debian_component_based-$_DATE', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:debian_component_based', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:$TAG_NAME-debian_component_based-$_DATE', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:debian_component_based', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:$TAG_NAME-debian_component_based-$_DATE', 'debian_component_based/', '--push']
   waitFor: ['multi_arch_step3']
 - name: 'gcr.io/cloud-builders/docker'
   id: multi_arch_alpine
-  args: ['buildx', 'build', '--build-arg', 'CLOUD_SDK_VERSION=$_CLI_VERSION', '--platform', 'linux/arm64,linux/amd64', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:alpine', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:$TAG_NAME-alpine', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:$TAG_NAME-alpine-$_DATE', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:alpine', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:$TAG_NAME-alpine', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:$TAG_NAME-alpine-$_DATE', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:alpine', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:$TAG_NAME-alpine', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:$TAG_NAME-alpine-$_DATE', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:alpine', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:$TAG_NAME-alpine', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:$TAG_NAME-alpine-$_DATE', 'alpine/', '--push']
+  args: ['buildx', 'build', '--build-arg', 'CLOUD_SDK_VERSION=$_CLI_VERSION', '--platform', 'linux/arm64,linux/amd64', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:alpine', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:$TAG_NAME-alpine-$_DATE', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:alpine', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:$TAG_NAME-alpine-$_DATE', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:alpine', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:$TAG_NAME-alpine-$_DATE', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:alpine', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:$TAG_NAME-alpine-$_DATE', 'alpine/', '--push']
   waitFor: ['multi_arch_step3']
 - name: 'gcr.io/cloud-builders/docker'
   id: multi_arch_emulators
-  args: ['buildx', 'build', '--build-arg', 'CLOUD_SDK_VERSION=$_CLI_VERSION', '--platform', 'linux/arm64,linux/amd64', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:emulators', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:$TAG_NAME-emulators', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:$TAG_NAME-emulators-$_DATE', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:emulators', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:$TAG_NAME-emulators', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:$TAG_NAME-emulators-$_DATE', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:emulators', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:$TAG_NAME-emulators', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:$TAG_NAME-emulators-$_DATE', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:emulators', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:$TAG_NAME-emulators', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:$TAG_NAME-emulators-$_DATE', 'emulators/', '--push']
+  args: ['buildx', 'build', '--build-arg', 'CLOUD_SDK_VERSION=$_CLI_VERSION', '--platform', 'linux/arm64,linux/amd64', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:emulators', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:$TAG_NAME-emulators-$_DATE', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:emulators', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:$TAG_NAME-emulators-$_DATE', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:emulators', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:$TAG_NAME-emulators-$_DATE', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:emulators', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:$TAG_NAME-emulators-$_DATE', 'emulators/', '--push']
   waitFor: ['multi_arch_step3']
 - name: 'gcr.io/cloud-builders/docker'
   id: multi_arch_stable
-  args: ['buildx', 'build', '--build-arg', 'CLOUD_SDK_VERSION=$_CLI_VERSION', '--platform', 'linux/arm64,linux/amd64', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:stable', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:$TAG_NAME-stable', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:$TAG_NAME-stable-$_DATE', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:stable', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:$TAG_NAME-stable', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:$TAG_NAME-stable-$_DATE', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:stable', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:$TAG_NAME-stable', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:$TAG_NAME-stable-$_DATE', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:stable', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:$TAG_NAME-stable', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:$TAG_NAME-stable-$_DATE', 'stable/', '--push']
+  args: ['buildx', 'build', '--build-arg', 'CLOUD_SDK_VERSION=$_CLI_VERSION', '--platform', 'linux/arm64,linux/amd64', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:stable', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:$TAG_NAME-stable-$_DATE', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:stable', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:$TAG_NAME-stable-$_DATE', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:stable', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:$TAG_NAME-stable-$_DATE', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:stable', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:$TAG_NAME-stable-$_DATE', 'stable/', '--push']
   waitFor: ['multi_arch_step3']
 - name: 'gcr.io/cloud-builders/docker'
   id: multi_arch_default
-  args: ['buildx', 'build', '--build-arg', 'CLOUD_SDK_VERSION=$_CLI_VERSION', '--platform', 'linux/arm64,linux/amd64', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:latest', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:$TAG_NAME', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:$TAG_NAME-$_DATE', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:latest', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:$TAG_NAME', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:$TAG_NAME-$_DATE', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:latest', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:$TAG_NAME', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:$TAG_NAME-$_DATE', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:latest', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:$TAG_NAME', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:$TAG_NAME-$_DATE', '.', '--push']
+  args: ['buildx', 'build', '--build-arg', 'CLOUD_SDK_VERSION=$_CLI_VERSION', '--platform', 'linux/arm64,linux/amd64', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:latest', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:$TAG_NAME-$_DATE', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:latest', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:$TAG_NAME-$_DATE', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:latest', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:$TAG_NAME-$_DATE', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:latest', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:$TAG_NAME-$_DATE', '.', '--push']
   waitFor: ['multi_arch_step3']
 - name: 'gcr.io/cloud-builders/docker'
   id: dockersecret
@@ -93,50 +94,44 @@ steps:
   args: ['push', 'google/cloud-sdk:alpine']
   waitFor: ['dockersecret', 'alpine']
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['push', 'google/cloud-sdk:$TAG_NAME-alpine']
+  args: ['push', 'google/cloud-sdk:$TAG_NAME-alpine-$_DATE']
   waitFor: ['dockersecret', 'alpine']
 - name: 'gcr.io/cloud-builders/docker'
   args: ['push', 'google/cloud-sdk:slim']
   waitFor: ['dockersecret', 'debian_slim']
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['push', 'google/cloud-sdk:$TAG_NAME-slim']
+  args: ['push', 'google/cloud-sdk:$TAG_NAME-slim-$_DATE']
   waitFor: ['dockersecret', 'debian_slim']
 - name: 'gcr.io/cloud-builders/docker'
   args: ['push', 'google/cloud-sdk:latest']
   waitFor: ['dockersecret', 'default']
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['push', 'google/cloud-sdk:$TAG_NAME']
+  args: ['push', 'google/cloud-sdk:$TAG_NAME-$_DATE']
   waitFor: ['dockersecret', 'default']
 - name: 'gcr.io/cloud-builders/docker'
   args: ['push', 'google/cloud-sdk:debian_component_based']
   waitFor: ['dockersecret', 'debian_component_based']
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['push', 'google/cloud-sdk:$TAG_NAME-debian_component_based']
+  args: ['push', 'google/cloud-sdk:$TAG_NAME-debian_component_based-$_DATE']
   waitFor: ['dockersecret', 'debian_component_based']
 - name: 'gcr.io/cloud-builders/docker'
   args: ['push', 'google/cloud-sdk:emulators']
   waitFor: ['dockersecret', 'emulators']
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['push', 'google/cloud-sdk:$TAG_NAME-emulators']
+  args: ['push', 'google/cloud-sdk:$TAG_NAME-emulators-$_DATE']
   waitFor: ['dockersecret', 'emulators']
 - name: 'gcr.io/cloud-builders/docker'
   args: ['push', 'google/cloud-sdk:stable']
   waitFor: ['dockersecret', 'stable']
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['push', 'google/cloud-sdk:$TAG_NAME-stable']
+  args: ['push', 'google/cloud-sdk:$TAG_NAME-stable-$_DATE']
   waitFor: ['dockersecret', 'stable']
 images:
-- 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:$TAG_NAME'
 - 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:$TAG_NAME-$_DATE'
-- 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:$TAG_NAME-alpine'
 - 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:$TAG_NAME-alpine-$_DATE'
-- 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:$TAG_NAME-debian_component_based'
 - 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:$TAG_NAME-debian_component_based-$_DATE'
-- 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:$TAG_NAME-emulators'
 - 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:$TAG_NAME-emulators-$_DATE'
-- 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:$TAG_NAME-slim'
 - 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:$TAG_NAME-slim-$_DATE'
-- 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:$TAG_NAME-stable'
 - 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:$TAG_NAME-stable-$_DATE'
 - 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:alpine'
 - 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:debian_component_based'
@@ -144,17 +139,11 @@ images:
 - 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:latest'
 - 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:slim'
 - 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:stable'
-- 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:$TAG_NAME'
 - 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:$TAG_NAME-$_DATE'
-- 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:$TAG_NAME-alpine'
 - 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:$TAG_NAME-alpine-$_DATE'
-- 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:$TAG_NAME-debian_component_based'
 - 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:$TAG_NAME-debian_component_based-$_DATE'
-- 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:$TAG_NAME-emulators'
 - 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:$TAG_NAME-emulators-$_DATE'
-- 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:$TAG_NAME-slim'
 - 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:$TAG_NAME-slim-$_DATE'
-- 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:$TAG_NAME-stable'
 - 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:$TAG_NAME-stable-$_DATE'
 - 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:alpine'
 - 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:debian_component_based'
@@ -162,17 +151,11 @@ images:
 - 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:latest'
 - 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:slim'
 - 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:stable'
-- 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:$TAG_NAME'
 - 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:$TAG_NAME-$_DATE'
-- 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:$TAG_NAME-alpine'
 - 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:$TAG_NAME-alpine-$_DATE'
-- 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:$TAG_NAME-debian_component_based'
 - 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:$TAG_NAME-debian_component_based-$_DATE'
-- 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:$TAG_NAME-emulators'
 - 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:$TAG_NAME-emulators-$_DATE'
-- 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:$TAG_NAME-slim'
 - 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:$TAG_NAME-slim-$_DATE'
-- 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:$TAG_NAME-stable'
 - 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:$TAG_NAME-stable-$_DATE'
 - 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:alpine'
 - 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:debian_component_based'
@@ -181,17 +164,11 @@ images:
 - 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:slim'
 - 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:stable'
 - 'us-docker.pkg.dev/google.com/cloudsdktool/scanning/google-cloud-cli:all_components'
-- 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:$TAG_NAME'
 - 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:$TAG_NAME-$_DATE'
-- 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:$TAG_NAME-alpine'
 - 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:$TAG_NAME-alpine-$_DATE'
-- 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:$TAG_NAME-debian_component_based'
 - 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:$TAG_NAME-debian_component_based-$_DATE'
-- 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:$TAG_NAME-emulators'
 - 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:$TAG_NAME-emulators-$_DATE'
-- 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:$TAG_NAME-slim'
 - 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:$TAG_NAME-slim-$_DATE'
-- 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:$TAG_NAME-stable'
 - 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:$TAG_NAME-stable-$_DATE'
 - 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:alpine'
 - 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:debian_component_based'

--- a/cloudbuild-hotfix.yaml
+++ b/cloudbuild-hotfix.yaml
@@ -1,4 +1,3 @@
-# IT IS A HOTFIX
 # PROD BUILDING STEPS
 options:
   logging: GCS_ONLY
@@ -38,48 +37,52 @@ steps:
   waitFor: ['-']
 - name: 'gcr.io/cloud-builders/docker'
   id: alpine
-  args: ['build', '--build-arg', 'CLOUD_SDK_VERSION=$_CLI_VERSION', '-t', 'google/cloud-sdk:alpine', '-t', 'google/cloud-sdk:$TAG_NAME-alpine-$_DATE', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:alpine', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:$TAG_NAME-alpine-$_DATE', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:alpine', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:$TAG_NAME-alpine-$_DATE', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:alpine', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:$TAG_NAME-alpine-$_DATE', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:alpine', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:$TAG_NAME-alpine-$_DATE', 'alpine/']
+  args: ['build', '--build-arg', 'CLOUD_SDK_VERSION=$_CLI_VERSION', '-t', 'google/cloud-sdk:alpine', '-t', 'google/cloud-sdk:$TAG_NAME-alpine', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:alpine', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:$TAG_NAME-alpine', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:$TAG_NAME-alpine-$_DATE', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:alpine', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:$TAG_NAME-alpine', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:$TAG_NAME-alpine-$_DATE', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:alpine', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:$TAG_NAME-alpine', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:$TAG_NAME-alpine-$_DATE', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:alpine', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:$TAG_NAME-alpine', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:$TAG_NAME-alpine-$_DATE', 'alpine/']
   waitFor: ['-']
 - name: 'gcr.io/cloud-builders/docker'
   id: debian_slim
-  args: ['build', '--build-arg', 'CLOUD_SDK_VERSION=$_CLI_VERSION', '-t', 'google/cloud-sdk:slim', '-t', 'google/cloud-sdk:$TAG_NAME-slim-$_DATE', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:slim', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:$TAG_NAME-slim-$_DATE', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:slim', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:$TAG_NAME-slim-$_DATE', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:slim', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:$TAG_NAME-slim-$_DATE', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:slim', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:$TAG_NAME-slim-$_DATE', 'debian_slim/']
+  args: ['build', '--build-arg', 'CLOUD_SDK_VERSION=$_CLI_VERSION', '-t', 'google/cloud-sdk:slim', '-t', 'google/cloud-sdk:$TAG_NAME-slim', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:slim', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:$TAG_NAME-slim', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:$TAG_NAME-slim-$_DATE', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:slim', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:$TAG_NAME-slim', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:$TAG_NAME-slim-$_DATE', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:slim', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:$TAG_NAME-slim', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:$TAG_NAME-slim-$_DATE', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:slim', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:$TAG_NAME-slim', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:$TAG_NAME-slim-$_DATE', 'debian_slim/']
   waitFor: ['-']
 - name: 'gcr.io/cloud-builders/docker'
   id: default
-  args: ['build', '--build-arg', 'CLOUD_SDK_VERSION=$_CLI_VERSION', '-t', 'google/cloud-sdk:latest', '-t', 'google/cloud-sdk:$TAG_NAME-$_DATE', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:latest', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:$TAG_NAME-$_DATE', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:latest', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:$TAG_NAME-$_DATE', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:latest', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:$TAG_NAME-$_DATE', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:latest', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:$TAG_NAME-$_DATE', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:latest', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:$TAG_NAME-$_DATE', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:latest', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:$TAG_NAME-$_DATE', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:latest', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:$TAG_NAME-$_DATE', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:latest', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:$TAG_NAME-$_DATE', '.']
+  args: ['build', '--build-arg', 'CLOUD_SDK_VERSION=$_CLI_VERSION', '-t', 'google/cloud-sdk:latest', '-t', 'google/cloud-sdk:$TAG_NAME', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:latest', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:$TAG_NAME', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:$TAG_NAME-$_DATE', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:latest', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:$TAG_NAME', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:$TAG_NAME-$_DATE', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:latest', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:$TAG_NAME', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:$TAG_NAME-$_DATE', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:latest', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:$TAG_NAME', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:$TAG_NAME-$_DATE', '.']
   waitFor: ['-']
 - name: 'gcr.io/cloud-builders/docker'
   id: debian_component_based
-  args: ['build', '--build-arg', 'CLOUD_SDK_VERSION=$_CLI_VERSION', '-t', 'google/cloud-sdk:debian_component_based', '-t', 'google/cloud-sdk:$TAG_NAME-debian_component_based-$_DATE', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:debian_component_based', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:$TAG_NAME-debian_component_based-$_DATE', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:debian_component_based', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:$TAG_NAME-debian_component_based-$_DATE', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:debian_component_based', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:$TAG_NAME-debian_component_based-$_DATE', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:debian_component_based', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:$TAG_NAME-debian_component_based-$_DATE', 'debian_component_based/']
+  args: ['build', '--build-arg', 'CLOUD_SDK_VERSION=$_CLI_VERSION', '-t', 'google/cloud-sdk:debian_component_based', '-t', 'google/cloud-sdk:$TAG_NAME-debian_component_based', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:debian_component_based', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:$TAG_NAME-debian_component_based', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:$TAG_NAME-debian_component_based-$_DATE', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:debian_component_based', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:$TAG_NAME-debian_component_based', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:$TAG_NAME-debian_component_based-$_DATE', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:debian_component_based', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:$TAG_NAME-debian_component_based', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:$TAG_NAME-debian_component_based-$_DATE', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:debian_component_based', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:$TAG_NAME-debian_component_based', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:$TAG_NAME-debian_component_based-$_DATE', 'debian_component_based/']
   waitFor: ['-']
 - name: 'gcr.io/cloud-builders/docker'
   id: emulators
-  args: ['build', '--build-arg', 'CLOUD_SDK_VERSION=$_CLI_VERSION', '-t', 'google/cloud-sdk:emulators', '-t', 'google/cloud-sdk:$TAG_NAME-emulators-$_DATE', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:emulators', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:$TAG_NAME-emulators-$_DATE', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:emulators', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:$TAG_NAME-emulators-$_DATE', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:emulators', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:$TAG_NAME-emulators-$_DATE', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:emulators', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:$TAG_NAME-emulators-$_DATE', 'emulators/']
+  args: ['build', '--build-arg', 'CLOUD_SDK_VERSION=$_CLI_VERSION', '-t', 'google/cloud-sdk:emulators', '-t', 'google/cloud-sdk:$TAG_NAME-emulators', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:emulators', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:$TAG_NAME-emulators', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:$TAG_NAME-emulators-$_DATE', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:emulators', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:$TAG_NAME-emulators', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:$TAG_NAME-emulators-$_DATE', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:emulators', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:$TAG_NAME-emulators', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:$TAG_NAME-emulators-$_DATE', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:emulators', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:$TAG_NAME-emulators', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:$TAG_NAME-emulators-$_DATE', 'emulators/']
   waitFor: ['-']
 - name: 'gcr.io/cloud-builders/docker'
   id: stable
-  args: ['build', '--build-arg', 'CLOUD_SDK_VERSION=$_CLI_VERSION', '-t', 'google/cloud-sdk:stable', '-t', 'google/cloud-sdk:$TAG_NAME-stable-$_DATE', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:stable', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:$TAG_NAME-stable-$_DATE', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:stable', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:$TAG_NAME-stable-$_DATE', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:stable', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:$TAG_NAME-stable-$_DATE', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:stable', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:$TAG_NAME-stable-$_DATE', 'stable/']
+  args: ['build', '--build-arg', 'CLOUD_SDK_VERSION=$_CLI_VERSION', '-t', 'google/cloud-sdk:stable', '-t', 'google/cloud-sdk:$TAG_NAME-stable', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:stable', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:$TAG_NAME-stable', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:$TAG_NAME-stable-$_DATE', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:stable', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:$TAG_NAME-stable', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:$TAG_NAME-stable-$_DATE', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:stable', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:$TAG_NAME-stable', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:$TAG_NAME-stable-$_DATE', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:stable', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:$TAG_NAME-stable', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:$TAG_NAME-stable-$_DATE', 'stable/']
   waitFor: ['-']
 # END OF PROD BUILDING STEPS
 - name: 'gcr.io/cloud-builders/docker'
   id: multi_arch_debian_slim
-  args: ['buildx', 'build', '--build-arg', 'CLOUD_SDK_VERSION=$_CLI_VERSION', '--platform', 'linux/arm64,linux/amd64', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:slim', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:$TAG_NAME-slim-$_DATE', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:slim', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:$TAG_NAME-slim-$_DATE', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:slim', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:$TAG_NAME-slim-$_DATE', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:slim', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:$TAG_NAME-slim-$_DATE', 'debian_slim/', '--push']
+  args: ['buildx', 'build', '--build-arg', 'CLOUD_SDK_VERSION=$_CLI_VERSION', '--platform', 'linux/arm64,linux/amd64', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:slim', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:$TAG_NAME-slim', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:$TAG_NAME-slim-$_DATE', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:slim', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:$TAG_NAME-slim', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:$TAG_NAME-slim-$_DATE', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:slim', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:$TAG_NAME-slim', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:$TAG_NAME-slim-$_DATE', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:slim', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:$TAG_NAME-slim', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:$TAG_NAME-slim-$_DATE', 'debian_slim/', '--push']
   waitFor: ['multi_arch_step3']
 - name: 'gcr.io/cloud-builders/docker'
   id: multi_arch_debian_component_based
-  args: ['buildx', 'build', '--build-arg', 'CLOUD_SDK_VERSION=$_CLI_VERSION', '--platform', 'linux/arm64,linux/amd64', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:debian_component_based', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:$TAG_NAME-debian_component_based-$_DATE', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:debian_component_based', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:$TAG_NAME-debian_component_based-$_DATE', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:debian_component_based', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:$TAG_NAME-debian_component_based-$_DATE', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:debian_component_based', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:$TAG_NAME-debian_component_based-$_DATE', 'debian_component_based/', '--push']
+  args: ['buildx', 'build', '--build-arg', 'CLOUD_SDK_VERSION=$_CLI_VERSION', '--platform', 'linux/arm64,linux/amd64', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:debian_component_based', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:$TAG_NAME-debian_component_based', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:$TAG_NAME-debian_component_based-$_DATE', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:debian_component_based', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:$TAG_NAME-debian_component_based', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:$TAG_NAME-debian_component_based-$_DATE', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:debian_component_based', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:$TAG_NAME-debian_component_based', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:$TAG_NAME-debian_component_based-$_DATE', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:debian_component_based', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:$TAG_NAME-debian_component_based', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:$TAG_NAME-debian_component_based-$_DATE', 'debian_component_based/', '--push']
   waitFor: ['multi_arch_step3']
 - name: 'gcr.io/cloud-builders/docker'
   id: multi_arch_alpine
-  args: ['buildx', 'build', '--build-arg', 'CLOUD_SDK_VERSION=$_CLI_VERSION', '--platform', 'linux/arm64,linux/amd64', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:alpine', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:$TAG_NAME-alpine-$_DATE', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:alpine', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:$TAG_NAME-alpine-$_DATE', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:alpine', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:$TAG_NAME-alpine-$_DATE', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:alpine', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:$TAG_NAME-alpine-$_DATE', 'alpine/', '--push']
+  args: ['buildx', 'build', '--build-arg', 'CLOUD_SDK_VERSION=$_CLI_VERSION', '--platform', 'linux/arm64,linux/amd64', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:alpine', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:$TAG_NAME-alpine', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:$TAG_NAME-alpine-$_DATE', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:alpine', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:$TAG_NAME-alpine', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:$TAG_NAME-alpine-$_DATE', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:alpine', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:$TAG_NAME-alpine', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:$TAG_NAME-alpine-$_DATE', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:alpine', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:$TAG_NAME-alpine', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:$TAG_NAME-alpine-$_DATE', 'alpine/', '--push']
   waitFor: ['multi_arch_step3']
 - name: 'gcr.io/cloud-builders/docker'
   id: multi_arch_emulators
-  args: ['buildx', 'build', '--build-arg', 'CLOUD_SDK_VERSION=$_CLI_VERSION', '--platform', 'linux/arm64,linux/amd64', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:emulators', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:$TAG_NAME-emulators-$_DATE', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:emulators', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:$TAG_NAME-emulators-$_DATE', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:emulators', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:$TAG_NAME-emulators-$_DATE', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:emulators', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:$TAG_NAME-emulators-$_DATE', 'emulators/', '--push']
+  args: ['buildx', 'build', '--build-arg', 'CLOUD_SDK_VERSION=$_CLI_VERSION', '--platform', 'linux/arm64,linux/amd64', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:emulators', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:$TAG_NAME-emulators', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:$TAG_NAME-emulators-$_DATE', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:emulators', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:$TAG_NAME-emulators', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:$TAG_NAME-emulators-$_DATE', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:emulators', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:$TAG_NAME-emulators', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:$TAG_NAME-emulators-$_DATE', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:emulators', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:$TAG_NAME-emulators', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:$TAG_NAME-emulators-$_DATE', 'emulators/', '--push']
   waitFor: ['multi_arch_step3']
 - name: 'gcr.io/cloud-builders/docker'
   id: multi_arch_stable
-  args: ['buildx', 'build', '--build-arg', 'CLOUD_SDK_VERSION=$_CLI_VERSION', '--platform', 'linux/arm64,linux/amd64', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:stable', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:$TAG_NAME-stable-$_DATE', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:stable', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:$TAG_NAME-stable-$_DATE', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:stable', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:$TAG_NAME-stable-$_DATE', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:stable', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:$TAG_NAME-stable-$_DATE', 'stable/', '--push']
+  args: ['buildx', 'build', '--build-arg', 'CLOUD_SDK_VERSION=$_CLI_VERSION', '--platform', 'linux/arm64,linux/amd64', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:stable', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:$TAG_NAME-stable', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:$TAG_NAME-stable-$_DATE', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:stable', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:$TAG_NAME-stable', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:$TAG_NAME-stable-$_DATE', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:stable', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:$TAG_NAME-stable', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:$TAG_NAME-stable-$_DATE', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:stable', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:$TAG_NAME-stable', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:$TAG_NAME-stable-$_DATE', 'stable/', '--push']
+  waitFor: ['multi_arch_step3']
+- name: 'gcr.io/cloud-builders/docker'
+  id: multi_arch_default
+  args: ['buildx', 'build', '--build-arg', 'CLOUD_SDK_VERSION=$_CLI_VERSION', '--platform', 'linux/arm64,linux/amd64', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:latest', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:$TAG_NAME', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:$TAG_NAME-$_DATE', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:latest', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:$TAG_NAME', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:$TAG_NAME-$_DATE', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:latest', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:$TAG_NAME', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:$TAG_NAME-$_DATE', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:latest', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:$TAG_NAME', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:$TAG_NAME-$_DATE', '.', '--push']
   waitFor: ['multi_arch_step3']
 - name: 'gcr.io/cloud-builders/docker'
   id: dockersecret
@@ -90,44 +93,50 @@ steps:
   args: ['push', 'google/cloud-sdk:alpine']
   waitFor: ['dockersecret', 'alpine']
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['push', 'google/cloud-sdk:$TAG_NAME-alpine-$_DATE']
+  args: ['push', 'google/cloud-sdk:$TAG_NAME-alpine']
   waitFor: ['dockersecret', 'alpine']
 - name: 'gcr.io/cloud-builders/docker'
   args: ['push', 'google/cloud-sdk:slim']
   waitFor: ['dockersecret', 'debian_slim']
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['push', 'google/cloud-sdk:$TAG_NAME-slim-$_DATE']
+  args: ['push', 'google/cloud-sdk:$TAG_NAME-slim']
   waitFor: ['dockersecret', 'debian_slim']
 - name: 'gcr.io/cloud-builders/docker'
   args: ['push', 'google/cloud-sdk:latest']
   waitFor: ['dockersecret', 'default']
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['push', 'google/cloud-sdk:$TAG_NAME-$_DATE']
+  args: ['push', 'google/cloud-sdk:$TAG_NAME']
   waitFor: ['dockersecret', 'default']
 - name: 'gcr.io/cloud-builders/docker'
   args: ['push', 'google/cloud-sdk:debian_component_based']
   waitFor: ['dockersecret', 'debian_component_based']
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['push', 'google/cloud-sdk:$TAG_NAME-debian_component_based-$_DATE']
+  args: ['push', 'google/cloud-sdk:$TAG_NAME-debian_component_based']
   waitFor: ['dockersecret', 'debian_component_based']
 - name: 'gcr.io/cloud-builders/docker'
   args: ['push', 'google/cloud-sdk:emulators']
   waitFor: ['dockersecret', 'emulators']
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['push', 'google/cloud-sdk:$TAG_NAME-emulators-$_DATE']
+  args: ['push', 'google/cloud-sdk:$TAG_NAME-emulators']
   waitFor: ['dockersecret', 'emulators']
 - name: 'gcr.io/cloud-builders/docker'
   args: ['push', 'google/cloud-sdk:stable']
   waitFor: ['dockersecret', 'stable']
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['push', 'google/cloud-sdk:$TAG_NAME-stable-$_DATE']
+  args: ['push', 'google/cloud-sdk:$TAG_NAME-stable']
   waitFor: ['dockersecret', 'stable']
 images:
+- 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:$TAG_NAME'
 - 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:$TAG_NAME-$_DATE'
+- 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:$TAG_NAME-alpine'
 - 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:$TAG_NAME-alpine-$_DATE'
+- 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:$TAG_NAME-debian_component_based'
 - 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:$TAG_NAME-debian_component_based-$_DATE'
+- 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:$TAG_NAME-emulators'
 - 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:$TAG_NAME-emulators-$_DATE'
+- 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:$TAG_NAME-slim'
 - 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:$TAG_NAME-slim-$_DATE'
+- 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:$TAG_NAME-stable'
 - 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:$TAG_NAME-stable-$_DATE'
 - 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:alpine'
 - 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:debian_component_based'
@@ -135,13 +144,17 @@ images:
 - 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:latest'
 - 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:slim'
 - 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:stable'
-- 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:$TAG_NAME-$_DATE'
-- 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:latest'
+- 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:$TAG_NAME'
 - 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:$TAG_NAME-$_DATE'
+- 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:$TAG_NAME-alpine'
 - 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:$TAG_NAME-alpine-$_DATE'
+- 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:$TAG_NAME-debian_component_based'
 - 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:$TAG_NAME-debian_component_based-$_DATE'
+- 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:$TAG_NAME-emulators'
 - 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:$TAG_NAME-emulators-$_DATE'
+- 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:$TAG_NAME-slim'
 - 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:$TAG_NAME-slim-$_DATE'
+- 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:$TAG_NAME-stable'
 - 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:$TAG_NAME-stable-$_DATE'
 - 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:alpine'
 - 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:debian_component_based'
@@ -149,13 +162,17 @@ images:
 - 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:latest'
 - 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:slim'
 - 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:stable'
-- 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:$TAG_NAME-$_DATE'
-- 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:latest'
+- 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:$TAG_NAME'
 - 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:$TAG_NAME-$_DATE'
+- 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:$TAG_NAME-alpine'
 - 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:$TAG_NAME-alpine-$_DATE'
+- 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:$TAG_NAME-debian_component_based'
 - 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:$TAG_NAME-debian_component_based-$_DATE'
+- 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:$TAG_NAME-emulators'
 - 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:$TAG_NAME-emulators-$_DATE'
+- 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:$TAG_NAME-slim'
 - 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:$TAG_NAME-slim-$_DATE'
+- 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:$TAG_NAME-stable'
 - 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:$TAG_NAME-stable-$_DATE'
 - 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:alpine'
 - 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:debian_component_based'
@@ -163,14 +180,18 @@ images:
 - 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:latest'
 - 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:slim'
 - 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:stable'
-- 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:$TAG_NAME-$_DATE'
-- 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:latest'
 - 'us-docker.pkg.dev/google.com/cloudsdktool/scanning/google-cloud-cli:all_components'
+- 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:$TAG_NAME'
 - 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:$TAG_NAME-$_DATE'
+- 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:$TAG_NAME-alpine'
 - 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:$TAG_NAME-alpine-$_DATE'
+- 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:$TAG_NAME-debian_component_based'
 - 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:$TAG_NAME-debian_component_based-$_DATE'
+- 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:$TAG_NAME-emulators'
 - 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:$TAG_NAME-emulators-$_DATE'
+- 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:$TAG_NAME-slim'
 - 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:$TAG_NAME-slim-$_DATE'
+- 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:$TAG_NAME-stable'
 - 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:$TAG_NAME-stable-$_DATE'
 - 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:alpine'
 - 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:debian_component_based'
@@ -178,8 +199,6 @@ images:
 - 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:latest'
 - 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:slim'
 - 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:stable'
-- 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:$TAG_NAME-$_DATE'
-- 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:latest'
 secrets:
 - kmsKeyName: projects/google.com:cloudsdktool/locations/global/keyRings/docker/cryptoKeys/dockerhub-password
   secretEnv:

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -45,7 +45,7 @@ steps:
   waitFor: ['-']
 - name: 'gcr.io/cloud-builders/docker'
   id: default
-  args: ['build', '--build-arg', 'CLOUD_SDK_VERSION=$_CLI_VERSION', '-t', 'google/cloud-sdk:latest', '-t', 'google/cloud-sdk:$TAG_NAME', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:latest', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:$TAG_NAME', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:$TAG_NAME-$_DATE', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:latest', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:$TAG_NAME', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:$TAG_NAME-$_DATE', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:latest', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:$TAG_NAME', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:$TAG_NAME-$_DATE', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:latest', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:$TAG_NAME', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:$TAG_NAME-$_DATE', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:latest', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:$TAG_NAME', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:$TAG_NAME-$_DATE', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:latest', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:$TAG_NAME', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:$TAG_NAME-$_DATE', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:latest', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:$TAG_NAME', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:$TAG_NAME-$_DATE', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:latest', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:$TAG_NAME', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:$TAG_NAME-$_DATE', '.']
+  args: ['build', '--build-arg', 'CLOUD_SDK_VERSION=$_CLI_VERSION', '-t', 'google/cloud-sdk:latest', '-t', 'google/cloud-sdk:$TAG_NAME', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:latest', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:$TAG_NAME', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:$TAG_NAME-$_DATE', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:latest', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:$TAG_NAME', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:$TAG_NAME-$_DATE', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:latest', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:$TAG_NAME', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:$TAG_NAME-$_DATE', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:latest', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:$TAG_NAME', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:$TAG_NAME-$_DATE', '.']
   waitFor: ['-']
 - name: 'gcr.io/cloud-builders/docker'
   id: debian_component_based
@@ -79,6 +79,10 @@ steps:
 - name: 'gcr.io/cloud-builders/docker'
   id: multi_arch_stable
   args: ['buildx', 'build', '--build-arg', 'CLOUD_SDK_VERSION=$_CLI_VERSION', '--platform', 'linux/arm64,linux/amd64', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:stable', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:$TAG_NAME-stable', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:$TAG_NAME-stable-$_DATE', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:stable', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:$TAG_NAME-stable', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:$TAG_NAME-stable-$_DATE', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:stable', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:$TAG_NAME-stable', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:$TAG_NAME-stable-$_DATE', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:stable', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:$TAG_NAME-stable', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:$TAG_NAME-stable-$_DATE', 'stable/', '--push']
+  waitFor: ['multi_arch_step3']
+- name: 'gcr.io/cloud-builders/docker'
+  id: multi_arch_default
+  args: ['buildx', 'build', '--build-arg', 'CLOUD_SDK_VERSION=$_CLI_VERSION', '--platform', 'linux/arm64,linux/amd64', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:latest', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:$TAG_NAME', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:$TAG_NAME-$_DATE', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:latest', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:$TAG_NAME', '-t', 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:$TAG_NAME-$_DATE', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:latest', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:$TAG_NAME', '-t', 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:$TAG_NAME-$_DATE', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:latest', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:$TAG_NAME', '-t', 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:$TAG_NAME-$_DATE', '.', '--push']
   waitFor: ['multi_arch_step3']
 - name: 'gcr.io/cloud-builders/docker'
   id: dockersecret
@@ -140,9 +144,6 @@ images:
 - 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:latest'
 - 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:slim'
 - 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/cloud-sdk:stable'
-- 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:$TAG_NAME'
-- 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:$TAG_NAME-$_DATE'
-- 'asia-docker.pkg.dev/google.com/cloudsdktool/asia.gcr.io/google-cloud-cli:latest'
 - 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:$TAG_NAME'
 - 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:$TAG_NAME-$_DATE'
 - 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:$TAG_NAME-alpine'
@@ -161,9 +162,6 @@ images:
 - 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:latest'
 - 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:slim'
 - 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/cloud-sdk:stable'
-- 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:$TAG_NAME'
-- 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:$TAG_NAME-$_DATE'
-- 'europe-docker.pkg.dev/google.com/cloudsdktool/eu.gcr.io/google-cloud-cli:latest'
 - 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:$TAG_NAME'
 - 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:$TAG_NAME-$_DATE'
 - 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:$TAG_NAME-alpine'
@@ -182,9 +180,6 @@ images:
 - 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:latest'
 - 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:slim'
 - 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/cloud-sdk:stable'
-- 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:$TAG_NAME'
-- 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:$TAG_NAME-$_DATE'
-- 'us-docker.pkg.dev/google.com/cloudsdktool/gcr.io/google-cloud-cli:latest'
 - 'us-docker.pkg.dev/google.com/cloudsdktool/scanning/google-cloud-cli:all_components'
 - 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:$TAG_NAME'
 - 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:$TAG_NAME-$_DATE'
@@ -204,9 +199,6 @@ images:
 - 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:latest'
 - 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:slim'
 - 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/cloud-sdk:stable'
-- 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:$TAG_NAME'
-- 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:$TAG_NAME-$_DATE'
-- 'us-docker.pkg.dev/google.com/cloudsdktool/us.gcr.io/google-cloud-cli:latest'
 secrets:
 - kmsKeyName: projects/google.com:cloudsdktool/locations/global/keyRings/docker/cryptoKeys/dockerhub-password
   secretEnv:

--- a/generate_cloudbuild.py
+++ b/generate_cloudbuild.py
@@ -65,7 +65,7 @@ DOCKERHUB_PREFIX='google'
 OLD_NAME='cloud-sdk'
 REBRAND_NAME='google-cloud-cli'
 IMAGES=['alpine', 'debian_slim', 'default', 'debian_component_based', 'emulators', 'stable']
-MULTI_ARCH=['debian_slim', 'debian_component_based', 'alpine', 'emulators', 'stable']
+MULTI_ARCH=['debian_slim', 'debian_component_based', 'alpine', 'emulators', 'stable', 'default']
 SCANNING_IMAGES=['all_components']
 LABEL_FOR_IMAGE={
     'alpine': 'alpine',


### PR DESCRIPTION
Add Arm support for the latest docker image.

Important note: `cloud-spanner-emulator` component is not supported on ARM.