### PR TITLE
Update `:latest` and `:slim` Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,6 @@ FROM marketplace.gcr.io/google/debian12:latest
 ARG CLOUD_SDK_VERSION
 ENV CLOUD_SDK_VERSION=$CLOUD_SDK_VERSION
 COPY --from=static-docker-source /usr/local/bin/docker /usr/local/bin/docker
-COPY --from=static-docker-source /usr/local/libexec/docker/cli-plugins/docker-buildx /usr/local/libexec/docker/cli-plugins/docker-buildx
 RUN groupadd -r -g 1000 cloudsdk && \
     useradd -r -u 1000 -m -s /bin/bash -g cloudsdk cloudsdk
 RUN apt-get update -qqy && apt-get -qqy upgrade && apt-get install -qqy \

--- a/debian_slim/Dockerfile
+++ b/debian_slim/Dockerfile
@@ -4,7 +4,6 @@ FROM marketplace.gcr.io/google/debian12:latest
 ARG CLOUD_SDK_VERSION
 ENV CLOUD_SDK_VERSION=$CLOUD_SDK_VERSION
 COPY --from=static-docker-source /usr/local/bin/docker /usr/local/bin/docker
-COPY --from=static-docker-source /usr/local/libexec/docker/cli-plugins/docker-buildx /usr/local/libexec/docker/cli-plugins/docker-buildx
 RUN groupadd -r -g 1000 cloudsdk && \
     useradd -r -u 1000 -m -s /bin/bash -g cloudsdk cloudsdk
 ARG INSTALL_COMPONENTS


### PR DESCRIPTION
We are removing the `docker-buildx` dependency from all Google Cloud CLI Docker images to mitigate customers’ exposure to vulnerabilities found in this component and its dependencies according to the following timeline. If your workflows rely on `docker-buildx`, you will need to pin to the respective `Pin-To` gcloud version or earlier. Alternatively, you could build your own docker image and include `docker-buildx` using a custom Dockerfile. Here are some examples: [Dockerfile Examples](https://cloud.google.com/sdk/docs/dockerfile_example). For any questions or concerns about the change, reach out to the [gcloud support team](https://b.corp.google.com/issues/new?component=187143&pli=1&template=800102).

|  Date  | Removed in gcloud version | `Pin-to` gcloud version to continue using `docker-buildx` | `docker-buildx` removed from images |
|:----------:|:-------------------------------------------:|:--------------------:|:----------:|
| Apr 22, 2025 | 519.0.0 | 518.0.0 | `:alpine` and `:debian_component_based` |
| May 20, 2025 | 523.0.0 | 522.0.0 | `:slim` and `:latest` |

As part of the change, this PR is removing `docker-buildx` package from the `:slim` and the `:latest` images.