### PR TITLE
Install openjdk-21-jre-headless from Debian sid repository

### DIFF
--- a/all_components/Dockerfile
+++ b/all_components/Dockerfile
@@ -4,7 +4,10 @@ ENV CLOUD_SDK_VERSION=$CLOUD_SDK_VERSION
 ENV PATH /google-cloud-sdk/bin:$PATH
 RUN groupadd -r -g 1000 cloudsdk && \
     useradd -r -u 1000 -m -s /bin/bash -g cloudsdk cloudsdk
-RUN apt-get update -qqy && apt-get -qqy upgrade && apt-get install -qqy \
+RUN echo 'deb http://deb.debian.org/debian/ sid main' >> /etc/apt/sources.list && \
+    apt-get update && \
+    apt-get -qqy upgrade && \
+    apt-get -y install \
         curl \
         gcc \
         python3-dev \
@@ -15,8 +18,9 @@ RUN apt-get update -qqy && apt-get -qqy upgrade && apt-get install -qqy \
         openssh-client \
         git \
         make \
-        gnupg \	
-        openjdk-17-jre-headless
+        gnupg && \
+    apt-get -y -t sid install \
+        openjdk-21-jre-headless
 RUN if [ `uname -m` = 'x86_64' ]; then echo -n "x86_64" > /tmp/arch; else echo -n "arm" > /tmp/arch; fi;
 RUN ARCH=`cat /tmp/arch` && curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-${CLOUD_SDK_VERSION}-linux-${ARCH}.tar.gz && \
     tar xzf google-cloud-cli-${CLOUD_SDK_VERSION}-linux-${ARCH}.tar.gz && \

--- a/debian_component_based/Dockerfile
+++ b/debian_component_based/Dockerfile
@@ -7,7 +7,10 @@ ENV PATH /google-cloud-sdk/bin:$PATH
 COPY --from=static-docker-source /usr/local/bin/docker /usr/local/bin/docker
 RUN groupadd -r -g 1000 cloudsdk && \
     useradd -r -u 1000 -m -s /bin/bash -g cloudsdk cloudsdk
-RUN apt-get update -qqy && apt-get -qqy upgrade && apt-get install -qqy \
+RUN echo 'deb http://deb.debian.org/debian/ sid main' >> /etc/apt/sources.list && \
+    apt-get update && \
+    apt-get -qqy upgrade && \
+    apt-get -y install \
         curl \
         gcc \
         python3-dev \
@@ -18,8 +21,9 @@ RUN apt-get update -qqy && apt-get -qqy upgrade && apt-get install -qqy \
         openssh-client \
         git \
         make \
-        gnupg \
-	openjdk-17-jre-headless
+        gnupg && \
+    apt-get -qqy -t sid install \
+        openjdk-21-jre-headless
 RUN if [ `uname -m` = 'x86_64' ]; then echo -n "x86_64" > /tmp/arch; else echo -n "arm" > /tmp/arch; fi;
 RUN ARCH=`cat /tmp/arch` && curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-${CLOUD_SDK_VERSION}-linux-${ARCH}.tar.gz && \
     tar xzf google-cloud-cli-${CLOUD_SDK_VERSION}-linux-${ARCH}.tar.gz && \

--- a/emulators/Dockerfile
+++ b/emulators/Dockerfile
@@ -15,14 +15,16 @@ RUN if [ `uname -m` = 'x86_64' ]; then echo -n "x86_64" > /tmp/arch; else echo -
 
 RUN ARCH=`cat /tmp/arch` && \
     mkdir -p /usr/share/man/man1/ && \
+    echo 'deb http://deb.debian.org/debian/ sid main' >> /etc/apt/sources.list && \
     apt-get update && \
     apt-get -qqy upgrade && \
     apt-get -y install \
         curl \
         python3 \
         python3-crcmod \
-        bash \
-        openjdk-17-jre-headless && \
+        bash && \
+    apt-get -y -t sid install \
+        openjdk-21-jre-headless && \
     curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-${CLOUD_SDK_VERSION}-linux-${ARCH}.tar.gz && \
     tar xzf google-cloud-cli-${CLOUD_SDK_VERSION}-linux-${ARCH}.tar.gz && \
     rm google-cloud-cli-${CLOUD_SDK_VERSION}-linux-${ARCH}.tar.gz && \


### PR DESCRIPTION
Updated to install Java 21, as the Datastore and Firestore emulators now require Java 21 or higher.

> Removed support for running the Datastore emulator
(`gcloud beta emulators datastore start`) in environment with Java versions
prior to 21. Users can upgrade to Java 21 or above to continue using the latest
Datastore emulator. Alternatively, users can use previous gcloud CLI
versions to continue using the Datastore emulator with
Java 11 support.
Removed support for running the Firestore emulator
(`gcloud beta emulators firestore start`) in environment with Java versions
prior to 21. Users can upgrade to Java 21 or above to continue using the latest
Firestore emulator. Alternatively, users can use previous gcloud CLI
versions to continue using the previous Firestore emulator with
Java 11 support.

https://cloud.google.com/sdk/docs/release-notes#52300_2025-05-20

Fixes #559.