### PR TITLE
Install ARM-unavailable components only on x86_64

### DIFF
--- a/all_components/Dockerfile
+++ b/all_components/Dockerfile
@@ -23,7 +23,7 @@ RUN ARCH=`cat /tmp/arch` && curl -O https://dl.google.com/dl/cloudsdk/channels/r
     rm google-cloud-cli-${CLOUD_SDK_VERSION}-linux-${ARCH}.tar.gz
 RUN echo -n "anthoscli app-engine-java app-engine-python alpha beta pubsub-emulator cloud-datastore-emulator app-engine-go bigtable cbt app-engine-python-extras kubectl gke-gcloud-auth-plugin kustomize minikube skaffold kpt local-extract cloud-sql-proxy docker-credential-gcr package-go-module cloud-firestore-emulator cloud-run-proxy log-streaming managed-flink-client terraform-tools config-connector enterprise-certificate-proxy istioctl kubectl-oidc pkg" > /tmp/additional_components
 # These components are not available on ARM right now.
-RUN if [ `uname -m` = 'x86_64' ]; then echo -n " appctl nomos anthos-auth" >> /tmp/additional_components; fi;
+RUN if [ `uname -m` = 'x86_64' ]; then echo -n " appctl nomos anthos-auth cloud-spanner-emulator spanner-migration-tool" >> /tmp/additional_components; fi;
 RUN /google-cloud-sdk/install.sh --bash-completion=false --path-update=true --usage-reporting=false \
 	--additional-components `cat /tmp/additional_components` && rm -rf /google-cloud-sdk/.install/.backup
 RUN git config --system credential.'https://source.developers.google.com'.helper gcloud.sh

--- a/all_components/Dockerfile
+++ b/all_components/Dockerfile
@@ -21,7 +21,7 @@ RUN if [ `uname -m` = 'x86_64' ]; then echo -n "x86_64" > /tmp/arch; else echo -
 RUN ARCH=`cat /tmp/arch` && curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-${CLOUD_SDK_VERSION}-linux-${ARCH}.tar.gz && \
     tar xzf google-cloud-cli-${CLOUD_SDK_VERSION}-linux-${ARCH}.tar.gz && \
     rm google-cloud-cli-${CLOUD_SDK_VERSION}-linux-${ARCH}.tar.gz
-RUN echo -n "anthoscli app-engine-java app-engine-python alpha beta pubsub-emulator cloud-datastore-emulator app-engine-go bigtable cbt app-engine-python-extras kubectl gke-gcloud-auth-plugin kustomize minikube skaffold kpt local-extract cloud-sql-proxy docker-credential-gcr package-go-module cloud-firestore-emulator cloud-run-proxy cloud-spanner-emulator log-streaming managed-flink-client spanner-migration-tool terraform-tools config-connector enterprise-certificate-proxy istioctl kubectl-oidc pkg" > /tmp/additional_components
+RUN echo -n "anthoscli app-engine-java app-engine-python alpha beta pubsub-emulator cloud-datastore-emulator app-engine-go bigtable cbt app-engine-python-extras kubectl gke-gcloud-auth-plugin kustomize minikube skaffold kpt local-extract cloud-sql-proxy docker-credential-gcr package-go-module cloud-firestore-emulator cloud-run-proxy log-streaming managed-flink-client terraform-tools config-connector enterprise-certificate-proxy istioctl kubectl-oidc pkg" > /tmp/additional_components
 # These components are not available on ARM right now.
 RUN if [ `uname -m` = 'x86_64' ]; then echo -n " appctl nomos anthos-auth" >> /tmp/additional_components; fi;
 RUN /google-cloud-sdk/install.sh --bash-completion=false --path-update=true --usage-reporting=false \


### PR DESCRIPTION
Modified to install components that are unavailable on ARM only when running on x86_64.

```
ERROR: (gcloud.components.install) The following components are unknown [cloud-spanner-emulator, spanner-migration-tool].
```