### PR TITLE
Add docker buildx and compose plugins to slim image

### DIFF
--- a/debian_slim/Dockerfile
+++ b/debian_slim/Dockerfile
@@ -4,6 +4,7 @@ FROM marketplace.gcr.io/google/debian12:latest
 ARG CLOUD_SDK_VERSION
 ENV CLOUD_SDK_VERSION=$CLOUD_SDK_VERSION
 COPY --from=static-docker-source /usr/local/bin/docker /usr/local/bin/docker
+COPY --from=static-docker-source /usr/local/libexec/docker/cli-plugins /usr/local/libexec/docker/cli-plugins
 RUN groupadd -r -g 1000 cloudsdk && \
     useradd -r -u 1000 -m -s /bin/bash -g cloudsdk cloudsdk
 ARG INSTALL_COMPONENTS

--- a/debian_slim/Dockerfile
+++ b/debian_slim/Dockerfile
@@ -31,6 +31,8 @@ RUN apt-get update -qqy && apt-get -qqy upgrade && apt-get install -qqy \
     gsutil version -l && \
     bq version && \
     gcloud-crc32c /usr/bin/gcloud && \
-    docker --version
+    docker --version && \
+    docker buildx version && \
+    docker compose version
 RUN git config --system credential.'https://source.developers.google.com'.helper gcloud.sh
 VOLUME ["/root/.config"]


### PR DESCRIPTION
These are already included in the base static docker image. This allows full functionality of docker