### PR TITLE
Upgrade to java 21 for datastore and firestore emulators support 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@ ENV CLOUD_SDK_VERSION=$CLOUD_SDK_VERSION
 COPY --from=static-docker-source /usr/local/bin/docker /usr/local/bin/docker
 RUN groupadd -r -g 1000 cloudsdk && \
     useradd -r -u 1000 -m -s /bin/bash -g cloudsdk cloudsdk
-RUN echo 'deb http://deb.debian.org/debian/ sid main' >> /etc/apt/sources.list && \
-	apt-get update -qqy && apt-get -qqy upgrade && apt-get install -qqy \
+
+RUN apt-get update -qqy && apt-get -qqy upgrade && apt-get install -qqy \
         curl \
         python3-dev \
         python3-crcmod \
@@ -16,7 +16,11 @@ RUN echo 'deb http://deb.debian.org/debian/ sid main' >> /etc/apt/sources.list &
         openssh-client \
         git \
         make \
-        gnupg && \
+	gcc \
+	python3-pip \
+        gnupg
+RUN echo 'deb http://deb.debian.org/debian/ sid main' >> /etc/apt/sources.list && \
+    apt-get update -qqy && apt-get -qqy upgrade && \
     apt-get -y -t sid install openjdk-21-jre-headless
 RUN apt-get update -qqy 
 RUN export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)"
@@ -48,8 +52,5 @@ RUN apt-get update && \
     gcloud config set metrics/environment docker_image_latest && \
     gcloud --version && \
     docker --version && kubectl version --client
-RUN apt-get install -qqy \
-        gcc \
-        python3-pip
 RUN git config --system credential.'https://source.developers.google.com'.helper gcloud.sh
 VOLUME ["/root/.config", "/root/.kube"]

--- a/all_components/Dockerfile
+++ b/all_components/Dockerfile
@@ -17,7 +17,7 @@ RUN echo 'deb http://deb.debian.org/debian/ sid main' >> /etc/apt/sources.list &
         git \
         make \
         gnupg && \
-    apt-get -y sid install openjdk-21-jre-headless 
+    apt-get -y -t sid install openjdk-21-jre-headless
 RUN if [ `uname -m` = 'x86_64' ]; then echo -n "x86_64" > /tmp/arch; else echo -n "arm" > /tmp/arch; fi;
 RUN ARCH=`cat /tmp/arch` && curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-${CLOUD_SDK_VERSION}-linux-${ARCH}.tar.gz && \
     tar xzf google-cloud-cli-${CLOUD_SDK_VERSION}-linux-${ARCH}.tar.gz && \

--- a/all_components/Dockerfile
+++ b/all_components/Dockerfile
@@ -4,7 +4,8 @@ ENV CLOUD_SDK_VERSION=$CLOUD_SDK_VERSION
 ENV PATH /google-cloud-sdk/bin:$PATH
 RUN groupadd -r -g 1000 cloudsdk && \
     useradd -r -u 1000 -m -s /bin/bash -g cloudsdk cloudsdk
-RUN apt-get update -qqy && apt-get -qqy upgrade && apt-get install -qqy \
+RUN echo 'deb http://deb.debian.org/debian/ sid main' >> /etc/apt/sources.list && \
+    apt-get update -qqy && apt-get -qqy upgrade && apt-get install -qqy \
         curl \
         gcc \
         python3-dev \
@@ -15,8 +16,8 @@ RUN apt-get update -qqy && apt-get -qqy upgrade && apt-get install -qqy \
         openssh-client \
         git \
         make \
-        gnupg \	
-        openjdk-17-jre-headless
+        gnupg && \
+    apt-get -y sid install openjdk-21-jre-headless 
 RUN if [ `uname -m` = 'x86_64' ]; then echo -n "x86_64" > /tmp/arch; else echo -n "arm" > /tmp/arch; fi;
 RUN ARCH=`cat /tmp/arch` && curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-${CLOUD_SDK_VERSION}-linux-${ARCH}.tar.gz && \
     tar xzf google-cloud-cli-${CLOUD_SDK_VERSION}-linux-${ARCH}.tar.gz && \

--- a/debian_component_based/Dockerfile
+++ b/debian_component_based/Dockerfile
@@ -7,8 +7,7 @@ ENV PATH /google-cloud-sdk/bin:$PATH
 COPY --from=static-docker-source /usr/local/bin/docker /usr/local/bin/docker
 RUN groupadd -r -g 1000 cloudsdk && \
     useradd -r -u 1000 -m -s /bin/bash -g cloudsdk cloudsdk
-RUN echo 'deb http://deb.debian.org/debian/ sid main' >> /etc/apt/sources.list && \
-    apt-get update -qqy && apt-get -qqy upgrade && apt-get install -qqy \
+RUN apt-get update -qqy && apt-get -qqy upgrade && apt-get install -qqy \
         curl \
         gcc \
         python3-dev \
@@ -19,7 +18,9 @@ RUN echo 'deb http://deb.debian.org/debian/ sid main' >> /etc/apt/sources.list &
         openssh-client \
         git \
         make \
-        gnupg && \
+        gnupg
+RUN RUN echo 'deb http://deb.debian.org/debian/ sid main' >> /etc/apt/sources.list && \
+    apt-get update -qqy && apt-get -qqy upgrade && \
     apt-get -y -t sid install openjdk-21-jre-headless
 RUN if [ `uname -m` = 'x86_64' ]; then echo -n "x86_64" > /tmp/arch; else echo -n "arm" > /tmp/arch; fi;
 RUN ARCH=`cat /tmp/arch` && curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-${CLOUD_SDK_VERSION}-linux-${ARCH}.tar.gz && \

--- a/debian_component_based/Dockerfile
+++ b/debian_component_based/Dockerfile
@@ -7,7 +7,8 @@ ENV PATH /google-cloud-sdk/bin:$PATH
 COPY --from=static-docker-source /usr/local/bin/docker /usr/local/bin/docker
 RUN groupadd -r -g 1000 cloudsdk && \
     useradd -r -u 1000 -m -s /bin/bash -g cloudsdk cloudsdk
-RUN apt-get update -qqy && apt-get -qqy upgrade && apt-get install -qqy \
+RUN echo 'deb http://deb.debian.org/debian/ sid main' >> /etc/apt/sources.list && \
+    apt-get update -qqy && apt-get -qqy upgrade && apt-get install -qqy \
         curl \
         gcc \
         python3-dev \
@@ -18,8 +19,8 @@ RUN apt-get update -qqy && apt-get -qqy upgrade && apt-get install -qqy \
         openssh-client \
         git \
         make \
-        gnupg \
-	openjdk-17-jre-headless
+        gnupg && \
+    apt-get -y -t sid install openjdk-21-jre-headless
 RUN if [ `uname -m` = 'x86_64' ]; then echo -n "x86_64" > /tmp/arch; else echo -n "arm" > /tmp/arch; fi;
 RUN ARCH=`cat /tmp/arch` && curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-${CLOUD_SDK_VERSION}-linux-${ARCH}.tar.gz && \
     tar xzf google-cloud-cli-${CLOUD_SDK_VERSION}-linux-${ARCH}.tar.gz && \

--- a/debian_component_based/Dockerfile
+++ b/debian_component_based/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update -qqy && apt-get -qqy upgrade && apt-get install -qqy \
         git \
         make \
         gnupg
-RUN RUN echo 'deb http://deb.debian.org/debian/ sid main' >> /etc/apt/sources.list && \
+RUN echo 'deb http://deb.debian.org/debian/ sid main' >> /etc/apt/sources.list && \
     apt-get update -qqy && apt-get -qqy upgrade && \
     apt-get -y -t sid install openjdk-21-jre-headless
 RUN if [ `uname -m` = 'x86_64' ]; then echo -n "x86_64" > /tmp/arch; else echo -n "arm" > /tmp/arch; fi;

--- a/emulators/Dockerfile
+++ b/emulators/Dockerfile
@@ -15,14 +15,15 @@ RUN if [ `uname -m` = 'x86_64' ]; then echo -n "x86_64" > /tmp/arch; else echo -
 
 RUN ARCH=`cat /tmp/arch` && \
     mkdir -p /usr/share/man/man1/ && \
+    echo 'deb http://deb.debian.org/debian/ sid main' >> /etc/apt/sources.list && \
     apt-get update && \
     apt-get -qqy upgrade && \
     apt-get -y install \
         curl \
         python3 \
         python3-crcmod \
-        bash \
-        openjdk-17-jre-headless && \
+        bash && \
+    apt-get -y -t sid install openjdk-21-jre-headless && \
     curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-${CLOUD_SDK_VERSION}-linux-${ARCH}.tar.gz && \
     tar xzf google-cloud-cli-${CLOUD_SDK_VERSION}-linux-${ARCH}.tar.gz && \
     rm google-cloud-cli-${CLOUD_SDK_VERSION}-linux-${ARCH}.tar.gz && \

--- a/emulators/Dockerfile
+++ b/emulators/Dockerfile
@@ -15,7 +15,6 @@ RUN if [ `uname -m` = 'x86_64' ]; then echo -n "x86_64" > /tmp/arch; else echo -
 
 RUN ARCH=`cat /tmp/arch` && \
     mkdir -p /usr/share/man/man1/ && \
-    echo 'deb http://deb.debian.org/debian/ sid main' >> /etc/apt/sources.list && \
     apt-get update && \
     apt-get -qqy upgrade && \
     apt-get -y install \
@@ -23,6 +22,8 @@ RUN ARCH=`cat /tmp/arch` && \
         python3 \
         python3-crcmod \
         bash && \
+    echo 'deb http://deb.debian.org/debian/ sid main' >> /etc/apt/sources.list && \
+    apt-get update && apt-get -qqy upgrade && \
     apt-get -y -t sid install openjdk-21-jre-headless && \
     curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-${CLOUD_SDK_VERSION}-linux-${ARCH}.tar.gz && \
     tar xzf google-cloud-cli-${CLOUD_SDK_VERSION}-linux-${ARCH}.tar.gz && \


### PR DESCRIPTION
Datastore and Firestore team are releasing a new version of emulators on July 01, 2025, which will require java 21. As a result if we don't upgrade the java version for gcloud docker images customer workflow will break: https://github.com/GoogleCloudPlatform/cloud-sdk-docker/discussions/564

This PR updates the java version for gcloud docker images to reduce customer friction. 