### PR TITLE
Update `alpine` dockerfile

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,10 +1,7 @@
-FROM docker:28.2.2 as static-docker-source
-
 FROM alpine:3.20
 ARG CLOUD_SDK_VERSION
 ENV CLOUD_SDK_VERSION=$CLOUD_SDK_VERSION
 ENV PATH /google-cloud-sdk/bin:$PATH
-COPY --from=static-docker-source /usr/local/bin/docker /usr/local/bin/docker
 RUN addgroup -g 1000 -S cloudsdk && \
     adduser -u 1000 -S cloudsdk -G cloudsdk
 RUN if [ `uname -m` = 'x86_64' ]; then echo -n "x86_64" > /tmp/arch; else echo -n "arm" > /tmp/arch; fi;


### PR DESCRIPTION
We are removing the `docker` dependency from all Google Cloud CLI Docker images to mitigate customers’ exposure to vulnerabilities found in this component and its dependencies according to the following timeline. If your workflows rely on `docker`, you will need to pin to the respective `Pin-To` gcloud version or earlier. Alternatively, you could build your own docker image and include `docker` using a custom Dockerfile. Here are some examples: [Dockerfile Examples](https://cloud.google.com/sdk/docs/dockerfile_example). For any questions or concerns about the change, reach out to the [gcloud support team](https://b.corp.google.com/issues/new?component=187143&pli=1&template=800102).

|  Date  | Removed in gcloud version | `Pin-to` gcloud version to continue using `docker` | `docker` removed from images |
|:----------:|:-------------------------------------------:|:--------------------:|:----------:|
| Jul 01, 2025 | 529.0.0 | 528.0.0 | `:alpine` and `:debian_component_based` |
| Jul 22, 2025 | 531.0.0 | 530.0.0 | `:slim` and `:latest` |

As part of the change, this PR is removing `docker` package from the `:alpine` and the `:debian_component_based` images.