### PR TITLE
Roll back java-21 upgrade for latest image until the stable debian 13…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,20 +18,12 @@ RUN apt-get update -qqy && apt-get -qqy upgrade && apt-get install -qqy \
         make \
 	gcc \
 	python3-pip \
-        gnupg
-RUN echo 'deb http://deb.debian.org/debian/ sid main' >> /etc/apt/sources.list && \
-    apt-get update -qqy && apt-get -qqy upgrade && \
-    apt-get -y -t sid install openjdk-21-jre-headless
-RUN apt-get update -qqy 
-RUN export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)"
-RUN curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg \
-    | gpg --dearmor -o /etc/apt/trusted.gpg.d/google-cloud.gpg
-
-# Add the repo
-RUN echo "deb [signed-by=/etc/apt/trusted.gpg.d/google-cloud.gpg] http://packages.cloud.google.com/apt cloud-sdk main" \
-    > /etc/apt/sources.list.d/google-cloud-sdk.list 
-
-RUN apt-get update && \
+        gnupg && \
+    export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)" && \
+    echo "deb [signed-by=/etc/apt/trusted.gpg.d/google-cloud.gpg] http://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" \
+    	 > /etc/apt/sources.list.d/google-cloud-sdk.list && \
+    curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /etc/apt/trusted.gpg.d/google-cloud.gpg && \
+    apt-get update && \
     apt-get install -y google-cloud-cli=${CLOUD_SDK_VERSION}-0 \
         google-cloud-cli-app-engine-python=${CLOUD_SDK_VERSION}-0 \
         google-cloud-cli-app-engine-python-extras=${CLOUD_SDK_VERSION}-0 \


### PR DESCRIPTION
… is available

Roll back java-21 upgrade for latest image until the stable debian 13 is available. Adding java-21 from sid repository is causing a [Debian version inconsistency](https://github.com/GoogleCloudPlatform/cloud-sdk-docker/issues/589)