### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,20 +28,21 @@ We have previously removed the `docker-buildx` package from the
 gcloud CLI docker images. For more information about already
 removed packages, see the [announcements on GitHub](https://github.com/GoogleCloudPlatform/cloud-sdk-docker/discussions/categories/announcements?discussions_q=is%3Aopen+category%3AAnnouncements+label%3A3pPackageRemoval).
 
-***Jun 20, 2025***
+***Jul 14, 2025***
 
-**Support for gcloud firestore and datastore emulators with Java 17 or earlier is ending on July 01, 2025**
+**Support for gcloud firestore and datastore emulators with Java 17 or earlier has ended on July 01, 2025**
 
 > [!WARNING]  
-> The firestore & datastore emulators will require
+> The firestore & datastore emulators requires
 Java 21 or later starting with the gcloud release 529.0.0
-(July 01, 2025). After this change, the firestore
+(July 01, 2025). The firestore
 and datastore emulators will fail to start in environments with Java
-versions prior to 21. To fix this, users of the `:latest` images can use their own Dockerfile to upgrade to
+versions prior to 21. To fix this, users of the `:latest` image can migrate
+to the `:emulators` Docker image which is dedicated for the gcloud
+emulators. Alternatively they can use their own Dockerfile to upgrade to
 Java 21 or later to continue using the latest firestore and
 datastore emulators
-([examples](https://cloud.google.com/sdk/docs/dockerfile_example#build-your-own-gcloud-docker-image-for-java21)).
-Alternatively the users can pin-to gcloud version `528.0.0` or
+([examples](https://cloud.google.com/sdk/docs/dockerfile_example#build-your-own-gcloud-docker-image-for-java21)) or can pin-to gcloud version `528.0.0` or
 earlier where the prior java versions were supported. For any questions or
 concerns about the change, reach out to the
 [gcloud support team](https://issuetracker.google.com/issues/new?component=187143).

--- a/README.md
+++ b/README.md
@@ -37,8 +37,7 @@ removed packages, see the [announcements on GitHub](https://github.com/GoogleClo
 Java 21 or later starting with the gcloud release 529.0.0
 (July 01, 2025). After this change, the firestore
 and datastore emulators will fail to start in environments with Java
-versions prior to 21. To fix this, users of the `:latest`, `:emulators` and
-`:debian_component_based` images can use their own Dockerfile to upgrade to
+versions prior to 21. To fix this, users of the `:latest` images can use their own Dockerfile to upgrade to
 Java 21 or later to continue using the latest firestore and
 datastore emulators
 ([examples](https://cloud.google.com/sdk/docs/dockerfile_example#build-your-own-gcloud-docker-image-for-java21)).


### PR DESCRIPTION
Added Java 21 on `:debian_component_based` and `:emulators` image. So only the `:latest` image does not support Java 21 now.