### PR TITLE
Update Dockerfile for `:latest` and `:slim` image to remove the docke…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,6 @@
-FROM docker:28.2.2 as static-docker-source
-
 FROM marketplace.gcr.io/google/debian12:latest
 ARG CLOUD_SDK_VERSION
 ENV CLOUD_SDK_VERSION=$CLOUD_SDK_VERSION
-COPY --from=static-docker-source /usr/local/bin/docker /usr/local/bin/docker
 RUN groupadd -r -g 1000 cloudsdk && \
     useradd -r -u 1000 -m -s /bin/bash -g cloudsdk cloudsdk
 
@@ -43,6 +40,6 @@ RUN apt-get update -qqy && apt-get -qqy upgrade && apt-get install -qqy \
     gcloud config set component_manager/disable_update_check true && \
     gcloud config set metrics/environment docker_image_latest && \
     gcloud --version && \
-    docker --version && kubectl version --client
+    kubectl version --client
 RUN git config --system credential.'https://source.developers.google.com'.helper gcloud.sh
 VOLUME ["/root/.config", "/root/.kube"]

--- a/debian_slim/Dockerfile
+++ b/debian_slim/Dockerfile
@@ -1,9 +1,6 @@
-FROM docker:28.2.2 as static-docker-source
-
 FROM marketplace.gcr.io/google/debian12:latest
 ARG CLOUD_SDK_VERSION
 ENV CLOUD_SDK_VERSION=$CLOUD_SDK_VERSION
-COPY --from=static-docker-source /usr/local/bin/docker /usr/local/bin/docker
 RUN groupadd -r -g 1000 cloudsdk && \
     useradd -r -u 1000 -m -s /bin/bash -g cloudsdk cloudsdk
 ARG INSTALL_COMPONENTS
@@ -29,7 +26,6 @@ RUN apt-get update -qqy && apt-get -qqy upgrade && apt-get install -qqy \
     gcloud --version && \
     gsutil version -l && \
     bq version && \
-    gcloud-crc32c /usr/bin/gcloud && \
-    docker --version
+    gcloud-crc32c /usr/bin/gcloud 
 RUN git config --system credential.'https://source.developers.google.com'.helper gcloud.sh
 VOLUME ["/root/.config"]


### PR DESCRIPTION
We are removing the `docker` dependency from all Google Cloud CLI Docker images to mitigate customers’ exposure to vulnerabilities found in this component and its dependencies according to the following timeline. If your workflows rely on `docker`, you will need to pin to the respective `Pin-To` gcloud version or earlier. Alternatively, you could build your own docker image and include `docker` using a custom Dockerfile. Here are some examples: [Dockerfile Examples](https://cloud.google.com/sdk/docs/dockerfile_example). For any questions or concerns about the change, reach out to the [gcloud support team](https://b.corp.google.com/issues/new?component=187143&pli=1&template=800102).

|  Date  | Removed in gcloud version | `Pin-to` gcloud version to continue using `docker` | `docker` removed from images |
|:----------:|:-------------------------------------------:|:--------------------:|:----------:|
| Jul 01, 2025 | 529.0.0 | 528.0.0 | `:alpine` and `:debian_component_based` |
| Jul 22, 2025 | 531.0.0 | 530.0.0 | `:slim` and `:latest` |

As part of the change, this PR is removing `docker` package from the `:slim` and the `:latest` images.
