### PR TITLE
Update Dockerfile for `:latest` and `:debian_component_based` images to remove `make` package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,6 @@ RUN apt-get update -qqy && apt-get -qqy upgrade && apt-get install -qqy \
         lsb-release \
         openssh-client \
         git \
-        make \
 	gcc \
 	python3-pip \
         gnupg && \

--- a/debian_component_based/Dockerfile
+++ b/debian_component_based/Dockerfile
@@ -14,7 +14,6 @@ RUN apt-get update -qqy && apt-get -qqy upgrade && apt-get install -qqy \
         lsb-release \
         openssh-client \
         git \
-        make \
         gnupg
 RUN echo 'deb http://deb.debian.org/debian/ sid main' >> /etc/apt/sources.list && \
     apt-get update -qqy && apt-get -qqy upgrade && \


### PR DESCRIPTION
We are removing the `make` dependency from the `:latest` and `:debian_component_based` Google Cloud CLI Docker images to mitigate customers' exposure to vulnerabilities found in this component and its dependencies according to the [following timeline](#update-timeline). If your workflows rely on the `make` package, you will need to pin to the respective `Pin-To` gcloud version or earlier. Alternatively, you could build your own docker image and include `make` using a custom Dockerfile. 

### Update Timeline

|  <img width=100/> Date  | Removed in gcloud version | `Pin-to` gcloud version to continue using `make` | `make` removed from images | 
|:----------:|:-------------------------------------------:|:--------------------:|:----------:| 
| Aug 5, 2025 | 533.0.0 | 532.0.0 | `:latest` and `:debian_component_based` |