### PR TITLE
Add GitHub Action to sync README with Docker Hub description

### DIFF
--- a/.github/workflows/dockerhub-description.yml
+++ b/.github/workflows/dockerhub-description.yml
@@ -1,0 +1,24 @@
+name: Update Docker Hub Description
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'README.md'
+  workflow_dispatch:
+
+jobs:
+  dockerhub-desc:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Source Code
+        uses: actions/checkout@v4
+
+      - name: Docker Hub Description
+        uses: peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa # v5.0.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: google/cloud-sdk
+          short-description: "Docker Image for Google Cloud CLI"


### PR DESCRIPTION
This PR adds a GitHub Actions workflow that uses `peter-evans/dockerhub-description` to automatically sync the `README.md` of this repository to the `google/cloud-sdk` repository on Docker Hub.