### PR TITLE
fix: update `entrypoint.sh` to not use `apt-key`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,9 @@ RUN apt-get update -qqy && apt-get -qqy upgrade && apt-get install -qqy \
 	python3-pip \
         gnupg && \
     export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)" && \
-    echo "deb [signed-by=/etc/apt/trusted.gpg.d/google-cloud.gpg] http://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" \
-    	 > /etc/apt/sources.list.d/google-cloud-sdk.list && \
-    curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /etc/apt/trusted.gpg.d/google-cloud.gpg && \
+    echo "deb [signed-by=/etc/apt/keyrings/google-cloud-cli.gpg] https://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" \
+        > /etc/apt/sources.list.d/google-cloud-sdk.list && \
+    curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg  | gpg --dearmor -o /etc/apt/keyrings/google-cloud-cli.gpg && \
     apt-get update && \
     apt-get install -y google-cloud-cli=${CLOUD_SDK_VERSION}-0 \
         google-cloud-cli-app-engine-python=${CLOUD_SDK_VERSION}-0 \
@@ -33,7 +33,7 @@ RUN apt-get update -qqy && apt-get -qqy upgrade && apt-get install -qqy \
         google-cloud-cli-kpt=${CLOUD_SDK_VERSION}-0 \
         google-cloud-cli-local-extract=${CLOUD_SDK_VERSION}-0 \
         google-cloud-cli-gke-gcloud-auth-plugin=${CLOUD_SDK_VERSION}-0 \
-        kubectl 
+        kubectl
 RUN if [ `uname -m` = 'x86_64' ]; then apt-get install -y google-cloud-cli-spanner-emulator=${CLOUD_SDK_VERSION}-0; fi;
 RUN gcloud config set core/disable_usage_reporting true && \
     gcloud config set component_manager/disable_update_check true && \

--- a/debian_slim/Dockerfile
+++ b/debian_slim/Dockerfile
@@ -17,8 +17,9 @@ RUN apt-get update -qqy && apt-get -qqy upgrade && apt-get install -qqy \
         git \
         gnupg && \
     export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)" && \
+    echo "deb [signed-by=/etc/apt/keyrings/google-cloud-cli.gpg] https://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" \
+        > /etc/apt/sources.list.d/google-cloud-sdk.list && \
     curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg  | gpg --dearmor -o /etc/apt/keyrings/google-cloud-cli.gpg && \
-    echo "deb [signed-by=/etc/apt/keyrings/google-cloud-cli.gpg] https://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" > /etc/apt/sources.list.d/google-cloud-sdk.list && \
     apt-get update && apt-get install -y google-cloud-cli=${CLOUD_SDK_VERSION}-0 $INSTALL_COMPONENTS && \
     gcloud config set core/disable_usage_reporting true && \
     gcloud config set component_manager/disable_update_check true && \
@@ -26,6 +27,6 @@ RUN apt-get update -qqy && apt-get -qqy upgrade && apt-get install -qqy \
     gcloud --version && \
     gsutil version -l && \
     bq version && \
-    gcloud-crc32c /usr/bin/gcloud 
+    gcloud-crc32c /usr/bin/gcloud
 RUN git config --system credential.'https://source.developers.google.com'.helper gcloud.sh
 VOLUME ["/root/.config"]

--- a/stable/Dockerfile
+++ b/stable/Dockerfile
@@ -11,8 +11,9 @@ RUN apt-get update -qqy && apt-get -qqy upgrade && \
         lsb-release \
         gnupg && \
     export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)" && \
-    echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
-    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && \
+    echo "deb [signed-by=/etc/apt/keyrings/google-cloud-cli.gpg] https://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" \
+        > /etc/apt/sources.list.d/google-cloud-sdk.list && \
+    curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg  | gpg --dearmor -o /etc/apt/keyrings/google-cloud-cli.gpg && \
     apt-get update && \
     apt-get install -y --no-install-recommends google-cloud-cli=${CLOUD_SDK_VERSION}-0 $INSTALL_COMPONENTS &&\
     rm -rf /root/.cache/pip/ && \

--- a/stable/entrypoint.sh
+++ b/stable/entrypoint.sh
@@ -6,18 +6,19 @@ set -e
 if [ ! -z "$APT_PACKAGES" ]; then
       packages=$(echo $APT_PACKAGES | tr " " "\n")
       apt-get update && apt-get install -qqy $packages
-fi 
+fi
 
 if [ ! -z "$COMPONENTS" ]; then
       components=$(echo $COMPONENTS | tr " " "\n")
       apt-get update && apt-get install -qqy \
                 curl \
                 lsb-release \
-                gnupg 
+                gnupg
       export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)"
+      echo "deb [signed-by=/etc/apt/keyrings/google-cloud-cli.gpg] https://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" \
+          > /etc/apt/sources.list.d/google-cloud-sdk.list
       curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg  | gpg --dearmor -o /etc/apt/keyrings/google-cloud-cli.gpg
-      echo "deb [signed-by=/etc/apt/keyrings/google-cloud-cli.gpg] https://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" > /etc/apt/sources.list.d/google-cloud-sdk.list
-      
+
       echo $components
       apt-get update && apt-get install -qqy $components
 fi

--- a/stable/entrypoint.sh
+++ b/stable/entrypoint.sh
@@ -15,8 +15,8 @@ if [ ! -z "$COMPONENTS" ]; then
                 lsb-release \
                 gnupg 
       export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)"
-      echo "deb https://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" > /etc/apt/sources.list.d/google-cloud-sdk.list
-      curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
+      curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg  | gpg --dearmor -o /etc/apt/keyrings/google-cloud-cli.gpg
+      echo "deb [signed-by=/etc/apt/keyrings/google-cloud-cli.gpg] https://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" > /etc/apt/sources.list.d/google-cloud-sdk.list
       
       echo $components
       apt-get update && apt-get install -qqy $components


### PR DESCRIPTION
`apt-key` is removed in Debian `trixie`, so the `stable` image crashes on startup when additional components are requested (via the `COMPONENTS` variable).

This probably was missed when #395 addressed the deprecation; this PR applies the same fix to the missed code path.

This PR also unifies how gpg keys are loaded: they now all run the same command, and are stored in the same location `/etc/apt/keyrings`. This is the recommended location (instead of `/etc/apt/trusted.gpg.d` which was used previously), as keys in `/etc/apt/trusted.gpg.d` would be implicitly trusted by `apt` for all repositories on the system.

Ref: https://wiki.debian.org/SecureApt
Ref: https://wiki.debian.org/DebianRepository/UseThirdParty