### PR TITLE
Update alpine base image to python:3.14.4-alpine3.23

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,5 +1,5 @@
 ARG FINAL_STAGE=prod
-FROM alpine:3.23 AS prod
+FROM python:3.14.4-alpine3.23 AS prod
 ARG CLOUD_SDK_VERSION
 ENV CLOUD_SDK_VERSION=$CLOUD_SDK_VERSION
 ENV PATH=/google-cloud-sdk/bin:$PATH
@@ -9,18 +9,13 @@ RUN addgroup -g 1000 -S cloudsdk && \
 RUN if [ `uname -m` = 'x86_64' ]; then echo -n "x86_64" > /tmp/arch; else echo -n "arm" > /tmp/arch; fi; \
     ARCH=`cat /tmp/arch` && apk --no-cache upgrade && apk --no-cache add \
         curl \
-        python3 \
-        py3-pip \
-        py3-crcmod \
-        py3-openssl \
-        py3-grpcio \
         bash \
         libc6-compat \
         openssh-client \
         git \
         gnupg \
     && \
-    pip3 install --force-reinstall "pyOpenSSL==26.0.0" --break-system-packages && \
+    pip3 install --no-cache-dir crcmod pyOpenSSL==26.0.0 grpcio==1.80.0 && \
     if [ -z "$CLOUD_SDK_VERSION" ]; then \
         SDK_URL="https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-linux-${ARCH}.tar.gz"; \
         SDK_TAR="google-cloud-cli-linux-${ARCH}.tar.gz"; \


### PR DESCRIPTION
This PR updates the alpine base image in the alpine/Dockerfile to use `python:3.14.4-alpine3.23` instead of `alpine:3.23` and installs Python dependencies via pip3 to prevent environment conflicts.