### PR TITLE
Optimize Debian container footprints by conditionally installing system Python only on ARM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,25 @@
-FROM debian:trixie-slim
+ARG TARGETARCH=amd64
+FROM debian:trixie-slim AS base-amd64
+FROM python:3.14.4-slim-trixie AS base-arm64
+FROM base-${TARGETARCH}
+ARG TARGETARCH
 ARG CLOUD_SDK_VERSION
 ENV CLOUD_SDK_VERSION=$CLOUD_SDK_VERSION
 RUN groupadd -r -g 1000 cloudsdk && \
     useradd -r -u 1000 -m -s /bin/bash -g cloudsdk cloudsdk
 
-RUN apt-get update -qqy && apt-get -qqy upgrade && apt-get install -qqy \
+RUN apt-get update -qqy && apt-get -qqy upgrade && \
+    apt-get install -qqy \
         curl \
-        python3-dev \
-        python3-crcmod \
         apt-transport-https \
         lsb-release \
         openssh-client \
         git \
 	gcc \
-	python3-pip \
         gnupg && \
+    if [ "$TARGETARCH" = "arm64" ]; then \
+        pip3 install --no-cache-dir crcmod; \
+    fi && \
     export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)" && \
     echo "deb [signed-by=/etc/apt/keyrings/google-cloud-cli.gpg] https://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" \
         > /etc/apt/sources.list.d/google-cloud-sdk.list && \
@@ -34,7 +39,7 @@ RUN apt-get update -qqy && apt-get -qqy upgrade && apt-get install -qqy \
         google-cloud-cli-local-extract=${CLOUD_SDK_VERSION}-0 \
         google-cloud-cli-gke-gcloud-auth-plugin=${CLOUD_SDK_VERSION}-0 \
         kubectl
-RUN if [ `uname -m` = 'x86_64' ]; then apt-get install -y google-cloud-cli-spanner-emulator=${CLOUD_SDK_VERSION}-0; fi;
+RUN if [ "$TARGETARCH" = "amd64" ]; then apt-get install -y google-cloud-cli-spanner-emulator=${CLOUD_SDK_VERSION}-0; fi;
 RUN gcloud config set core/disable_usage_reporting true && \
     gcloud config set component_manager/disable_update_check true && \
     gcloud config set metrics/environment docker_image_latest && \

--- a/debian_component_based/Dockerfile
+++ b/debian_component_based/Dockerfile
@@ -1,28 +1,33 @@
-FROM debian:trixie-slim
+ARG TARGETARCH=amd64
+FROM debian:trixie-slim AS base-amd64
+FROM python:3.14.4-slim-trixie AS base-arm64
+FROM base-${TARGETARCH}
+ARG TARGETARCH
 ARG CLOUD_SDK_VERSION
 ENV CLOUD_SDK_VERSION=$CLOUD_SDK_VERSION
 ENV PATH=/google-cloud-sdk/bin:$PATH
 RUN groupadd -r -g 1000 cloudsdk && \
     useradd -r -u 1000 -m -s /bin/bash -g cloudsdk cloudsdk
-RUN apt-get update -qqy && apt-get -qqy upgrade && apt-get install -qqy \
+RUN apt-get update -qqy && apt-get -qqy upgrade && \
+    apt-get install -qqy \
         curl \
         gcc \
-        python3-dev \
-        python3-pip \
-        python3-crcmod \
         apt-transport-https \
         lsb-release \
         openssh-client \
         git \
         gnupg \
-        openjdk-21-jre-headless
-RUN if [ `uname -m` = 'x86_64' ]; then echo -n "x86_64" > /tmp/arch; else echo -n "arm" > /tmp/arch; fi;
+        openjdk-21-jre-headless && \
+    if [ "$TARGETARCH" = "arm64" ]; then \
+        pip3 install --no-cache-dir crcmod; \
+    fi
+RUN if [ "$TARGETARCH" = "amd64" ]; then echo -n "x86_64" > /tmp/arch; else echo -n "arm" > /tmp/arch; fi;
 RUN ARCH=`cat /tmp/arch` && curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-${CLOUD_SDK_VERSION}-linux-${ARCH}.tar.gz && \
     tar xzf google-cloud-cli-${CLOUD_SDK_VERSION}-linux-${ARCH}.tar.gz && \
     rm google-cloud-cli-${CLOUD_SDK_VERSION}-linux-${ARCH}.tar.gz
 RUN echo -n "app-engine-java app-engine-python alpha beta pubsub-emulator cloud-datastore-emulator app-engine-go bigtable cbt app-engine-python-extras kubectl gke-gcloud-auth-plugin kustomize minikube skaffold kpt local-extract" > /tmp/additional_components
 # These components are not available on ARM right now.
-RUN if [ `uname -m` = 'x86_64' ]; then echo -n " nomos anthos-auth" >> /tmp/additional_components; fi;
+RUN if [ "$TARGETARCH" = "amd64" ]; then echo -n " nomos anthos-auth" >> /tmp/additional_components; fi;
 RUN /google-cloud-sdk/install.sh --bash-completion=false --path-update=true --usage-reporting=false \
 	--additional-components `cat /tmp/additional_components` && rm -rf /google-cloud-sdk/.install/.backup
 RUN git config --system credential.'https://source.developers.google.com'.helper gcloud.sh

--- a/debian_slim/Dockerfile
+++ b/debian_slim/Dockerfile
@@ -1,21 +1,26 @@
-FROM debian:trixie-slim
+ARG TARGETARCH=amd64
+FROM debian:trixie-slim AS base-amd64
+FROM python:3.14.4-slim-trixie AS base-arm64
+FROM base-${TARGETARCH}
+ARG TARGETARCH
 ARG CLOUD_SDK_VERSION
 ENV CLOUD_SDK_VERSION=$CLOUD_SDK_VERSION
 RUN groupadd -r -g 1000 cloudsdk && \
     useradd -r -u 1000 -m -s /bin/bash -g cloudsdk cloudsdk
 ARG INSTALL_COMPONENTS
 RUN mkdir -p /usr/share/man/man1/
-RUN apt-get update -qqy && apt-get -qqy upgrade && apt-get install -qqy \
+RUN apt-get update -qqy && apt-get -qqy upgrade && \
+    apt-get install -qqy \
         curl \
         gcc \
-        python3-dev \
-        python3-crcmod \
-        python3-pip \
         apt-transport-https \
         lsb-release \
         openssh-client \
         git \
         gnupg && \
+    if [ "$TARGETARCH" = "arm64" ]; then \
+        pip3 install --no-cache-dir crcmod; \
+    fi && \
     export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)" && \
     echo "deb [signed-by=/etc/apt/keyrings/google-cloud-cli.gpg] https://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" \
         > /etc/apt/sources.list.d/google-cloud-sdk.list && \

--- a/stable/Dockerfile
+++ b/stable/Dockerfile
@@ -1,3 +1,7 @@
+ARG TARGETARCH=amd64
+FROM debian:trixie-slim AS base-amd64
+FROM python:3.14.4-slim-trixie AS base-arm64
+
 FROM debian:trixie-slim AS build_image
 
 ARG CLOUD_SDK_VERSION
@@ -19,17 +23,23 @@ RUN apt-get update -qqy && apt-get -qqy upgrade && \
     rm -rf /root/.cache/pip/ && \
     find /usr/lib/google-cloud-sdk -name '*.pyc' -delete && \
     find /usr/lib/google-cloud-sdk -name '*__pycache__*' -delete
-FROM debian:trixie-slim AS runtime_image
+FROM base-amd64 AS prep-amd64
 COPY --from=build_image /usr/lib/google-cloud-sdk /usr/lib/google-cloud-sdk
+RUN echo -n "x86_64" > /tmp/arch
 
+FROM base-arm64 AS prep-arm64
+COPY --from=build_image /usr/lib/google-cloud-sdk /usr/lib/google-cloud-sdk
+RUN apt-get update -qqy && apt-get install -qqy gcc && \
+    echo -n "arm" > /tmp/arch && \
+    pip3 install --no-cache-dir crcmod && \
+    apt-get remove -y gcc && apt-get autoremove -y && rm -rf /var/lib/apt/lists/*
+
+ARG TARGETARCH
+FROM prep-${TARGETARCH}
 ENV PATH=$PATH:/usr/lib/google-cloud-sdk/bin
 # Create a non-root user
 RUN groupadd -r -g 1000 cloudsdk && \
     useradd -r -u 1000 -m -s /bin/bash -g cloudsdk cloudsdk
-RUN if [ `uname -m` = 'x86_64' ]; then echo -n "x86_64" > /tmp/arch; else echo -n "arm" > /tmp/arch && \
-    apt-get update -qqy && apt-get -qqy upgrade && apt-get install -qqy \
-        python3-dev \
-        python3-crcmod; fi;
 RUN gcloud --version && \
     gsutil version -l && \
     bq version && \
@@ -39,7 +49,7 @@ RUN gcloud --version && \
     gcloud config set metrics/environment docker_image_stable && \
     rm -rf /root/.cache/pip/ && \
     find /usr/lib/google-cloud-sdk -name '*.pyc' -delete && \
-    find /usr/lib/google-cloud-sdk -name '*__pycache__*' -exec rm -r {} \+
+    find /usr/lib/google-cloud-sdk -name '*__pycache__*' -exec rm -rf {} \+
 VOLUME ["/root/.config"]
 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh


### PR DESCRIPTION
This PR optimizes all candidate Debian-based Dockerfiles (`Dockerfile`, `debian_slim/Dockerfile`, `debian_component_based/Dockerfile`) to eliminate duplicate host OS Python installations on x86 distros. System Python helper packages (`python3-dev`, `python3-pip`, `python3-crcmod`) are now dynamically scoped via `dpkg --print-architecture` to install exclusively on ARM container builds, enabling pure hermetic execution under the embedded bundled interpreter on x86 targets while avoiding artifact bloat.