### PR TITLE
fix: resolve relative paths in emulator smoke test scripts

### DIFF
--- a/debian_component_based/test-components.sh
+++ b/debian_component_based/test-components.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+
 echo "Checking gsutil version" 
 gsutil version
 
@@ -28,5 +30,4 @@ echo "Checking kubectl version"
 kubectl version
 
 echo "Checking the emulators"
-./test-all-emulators.sh
-
+"$SCRIPT_DIR/test-dcb-emulators.sh"

--- a/debian_component_based/test-dcb-emulators.sh
+++ b/debian_component_based/test-dcb-emulators.sh
@@ -1,7 +1,9 @@
 
 #!/bin/bash
 
-./emulator-testing.sh pubsub
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+
+"$SCRIPT_DIR/emulator-testing.sh" pubsub
 if [ $? -ne 0 ]; then 
 
     echo "Pub/sub emulator failed to execute."
@@ -9,7 +11,7 @@ if [ $? -ne 0 ]; then
 
 fi
 
-./emulator-testing.sh datastore
+"$SCRIPT_DIR/emulator-testing.sh" datastore
 if [ $? -ne 0 ]; then 
 
     echo "Datastore emulator failed to execute."
@@ -17,11 +19,10 @@ if [ $? -ne 0 ]; then
 
 fi
 
-./emulator-testing.sh bigtable
+"$SCRIPT_DIR/emulator-testing.sh" bigtable
 if [ $? -ne 0 ]; then
 
     echo "Bigtable emulator failed to execute."
     exit 1
 
 fi
-

--- a/emulators/test-all-emulators.sh
+++ b/emulators/test-all-emulators.sh
@@ -1,7 +1,9 @@
 
 #!/bin/bash
 
-./emulator-testing.sh pubsub
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+
+"$SCRIPT_DIR/emulator-testing.sh" pubsub
 if [ $? -ne 0 ]; then 
 
     echo "Pub/sub emulator failed to execute."
@@ -9,7 +11,7 @@ if [ $? -ne 0 ]; then
 
 fi
 
-./emulator-testing.sh datastore
+"$SCRIPT_DIR/emulator-testing.sh" datastore
 if [ $? -ne 0 ]; then 
 
     echo "Datastore emulator failed to execute."
@@ -17,7 +19,7 @@ if [ $? -ne 0 ]; then
 
 fi
 
-./emulator-testing.sh firestore
+"$SCRIPT_DIR/emulator-testing.sh" firestore
 if [ $? -ne 0 ]; then
 
     echo "Firestore emulator failed to execute."
@@ -25,7 +27,7 @@ if [ $? -ne 0 ]; then
 
 fi
 
-./emulator-testing.sh spanner
+"$SCRIPT_DIR/emulator-testing.sh" spanner
 if [ $? -ne 0 ]; then 
 
     echo "Spanner emulator failed to execute."
@@ -33,11 +35,10 @@ if [ $? -ne 0 ]; then
 
 fi
 
-./emulator-testing.sh bigtable
+"$SCRIPT_DIR/emulator-testing.sh" bigtable
 if [ $? -ne 0 ]; then
 
     echo "Bigtable emulator failed to execute."
     exit 1
 
 fi
-

--- a/test-all-emulators-latest.sh
+++ b/test-all-emulators-latest.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-./emulator-testing.sh pubsub
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+
+"$SCRIPT_DIR/emulators/emulator-testing.sh" pubsub
 if [ $? -ne 0 ]; then 
 
     echo "Pub/sub emulator failed to execute."
@@ -10,7 +12,7 @@ fi
 
 # TODO: datastore & firestore emulators are not supported on debian 12 because of Java 21 dependency
 
-# ./emulator-testing.sh datastore
+# "$SCRIPT_DIR/emulators/emulator-testing.sh" datastore
 # if [ $? -ne 0 ]; then 
 
 #    echo "Datastore emulator failed to execute."
@@ -18,7 +20,7 @@ fi
 
 # fi
 
-# ./emulator-testing.sh firestore
+# "$SCRIPT_DIR/emulators/emulator-testing.sh" firestore
 # if [ $? -ne 0 ]; then
 
 #    echo "Firestore emulator failed to execute."
@@ -26,7 +28,7 @@ fi
 
 # fi
 
-./emulator-testing.sh spanner
+"$SCRIPT_DIR/emulators/emulator-testing.sh" spanner
 if [ $? -ne 0 ]; then 
 
     echo "Spanner emulator failed to execute."
@@ -34,11 +36,10 @@ if [ $? -ne 0 ]; then
 
 fi
 
-./emulator-testing.sh bigtable
+"$SCRIPT_DIR/emulators/emulator-testing.sh" bigtable
 if [ $? -ne 0 ]; then
 
     echo "Bigtable emulator failed to execute."
     exit 1
 
 fi
-

--- a/test-latest.sh
+++ b/test-latest.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+
 echo "Checking gsutil version" 
 gsutil version
 
@@ -28,5 +30,4 @@ echo "Checking kubectl version"
 kubectl version
 
 echo "Checking the emulators"
-./test-all-emulators.sh
-
+"$SCRIPT_DIR/test-all-emulators-latest.sh"


### PR DESCRIPTION
Tiny shell paper cut fix.

These smoke-test helpers call sibling scripts with `./...`, so from repo root they blow up with `No such file or directory` before the emulator checks even start. Kinda annoying, pretty easy fix tho.

Repro:
```sh
bash ./test-latest.sh
bash ./debian_component_based/test-components.sh
```

This patch resolves helper paths from each script's own directory, so the same commands work from repo root and from inside the subdirs too. Low risk, just path plumbing really.

Checked:
- `bash -n` on the touched scripts
- mocked runs of both helper chains from repo root
- mocked run of `emulators/test-all-emulators.sh` from inside `emulators/`

Related context: #506, #593
