### PR TITLE
Optimize Debian image footprint using multi-stage builds.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,15 @@
-FROM debian:trixie-slim
+ARG TARGETARCH=amd64
+FROM debian:trixie-slim AS base-amd64
+ENV CLOUDSDK_PYTHON=/usr/lib/google-cloud-sdk/platform/bundledpythonunix/bin/python3
+
+FROM debian:trixie-slim AS base-arm64
+RUN apt-get update -qqy && apt-get -qqy upgrade && apt-get install -qqy \
+        python3 \
+        python3-crcmod && \
+    rm -rf /var/lib/apt/lists/*
+
+FROM debian:trixie-slim AS build_image
+
 ARG CLOUD_SDK_VERSION
 ENV CLOUD_SDK_VERSION=$CLOUD_SDK_VERSION
 RUN groupadd -r -g 1000 cloudsdk && \
@@ -35,6 +46,36 @@ RUN apt-get update -qqy && apt-get -qqy upgrade && apt-get install -qqy \
         google-cloud-cli-gke-gcloud-auth-plugin=${CLOUD_SDK_VERSION}-0 \
         kubectl
 RUN if [ `uname -m` = 'x86_64' ]; then apt-get install -y google-cloud-cli-spanner-emulator=${CLOUD_SDK_VERSION}-0; fi;
+
+RUN rm -rf /root/.cache/pip/ && \
+    find /usr/lib/google-cloud-sdk -name '*.pyc' -delete && \
+    find /usr/lib/google-cloud-sdk -name '*__pycache__*' -delete
+
+ARG TARGETARCH
+FROM base-${TARGETARCH} AS runtime_image
+ARG TARGETARCH
+COPY --from=build_image /usr/lib/google-cloud-sdk /usr/lib/google-cloud-sdk
+COPY --from=build_image /usr/bin/kubectl /usr/bin/kubectl
+RUN if [ "$TARGETARCH" = "amd64" ]; then \
+        ln -sf /usr/lib/google-cloud-sdk/platform/bundledpythonunix/bin/python3 /usr/bin/python3; \
+    fi && \
+    ln -sf /usr/bin/python3 /usr/bin/python
+
+ENV PATH=$PATH:/usr/lib/google-cloud-sdk/bin
+RUN groupadd -r -g 1000 cloudsdk && \
+    useradd -r -u 1000 -m -s /bin/bash -g cloudsdk cloudsdk
+
+RUN apt-get update -qqy && apt-get install -qqy \
+        curl \
+        apt-transport-https \
+        lsb-release \
+        openssh-client \
+        git \
+        gnupg && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN if [ "$TARGETARCH" = "amd64" ]; then echo -n "x86_64" > /tmp/arch; else echo -n "arm" > /tmp/arch; fi;
+
 RUN gcloud config set core/disable_usage_reporting true && \
     gcloud config set component_manager/disable_update_check true && \
     gcloud config set metrics/environment docker_image_latest && \
@@ -42,3 +83,4 @@ RUN gcloud config set core/disable_usage_reporting true && \
     kubectl version --client
 RUN git config --system credential.'https://source.developers.google.com'.helper gcloud.sh
 VOLUME ["/root/.config", "/root/.kube"]
+

--- a/all_components/Dockerfile
+++ b/all_components/Dockerfile
@@ -1,8 +1,17 @@
 ARG FINAL_STAGE=prod
-FROM debian:trixie-slim AS prod
+ARG TARGETARCH=amd64
+
+FROM debian:trixie-slim AS base-amd64
+ENV CLOUDSDK_PYTHON=/google-cloud-sdk/platform/bundledpythonunix/bin/python3
+
+FROM debian:trixie-slim AS base-arm64
+RUN apt-get update -qqy && apt-get -qqy upgrade && apt-get install -qqy \
+        python3 \
+        python3-crcmod && \
+    rm -rf /var/lib/apt/lists/*
+
+FROM debian:trixie-slim AS build_image
 ARG CLOUD_SDK_VERSION
-ENV CLOUD_SDK_VERSION=$CLOUD_SDK_VERSION
-ENV PATH=/google-cloud-sdk/bin:$PATH
 RUN groupadd -r -g 1000 cloudsdk && \
     useradd -r -u 1000 -m -s /bin/bash -g cloudsdk cloudsdk
 RUN apt-get update -qqy && apt-get -qqy upgrade && apt-get install -qqy \
@@ -31,12 +40,39 @@ RUN if [ `uname -m` = 'x86_64' ]; then echo -n "x86_64" > /tmp/arch; else echo -
     tar xzf "${SDK_TAR}" && \
     rm "${SDK_TAR}" && \
     echo -n "anthoscli app-engine-java app-engine-python alpha beta pubsub-emulator cloud-datastore-emulator app-engine-go bigtable cbt app-engine-python-extras kubectl gke-gcloud-auth-plugin kustomize minikube skaffold kpt local-extract cloud-sql-proxy docker-credential-gcr package-go-module cloud-firestore-emulator cloud-run-proxy log-streaming config-connector enterprise-certificate-proxy istioctl kubectl-oidc pkg" > /tmp/additional_components
-# These components are not available on ARM right now.
 RUN if [ `uname -m` = 'x86_64' ]; then echo -n " nomos anthos-auth cloud-spanner-emulator spanner-migration-tool" >> /tmp/additional_components; fi && \
     /google-cloud-sdk/install.sh --bash-completion=false --path-update=true --usage-reporting=false --additional-components `cat /tmp/additional_components` && \
     rm -rf /google-cloud-sdk/.install/.backup
+RUN cp /tmp/arch /google-cloud-sdk/arch
+
+ARG TARGETARCH
+FROM base-${TARGETARCH} AS prod
+ARG TARGETARCH
+COPY --from=build_image /google-cloud-sdk /google-cloud-sdk
+RUN if [ "$TARGETARCH" = "amd64" ]; then \
+        ln -sf /google-cloud-sdk/platform/bundledpythonunix/bin/python3 /usr/bin/python3; \
+    fi && \
+    ln -sf /usr/bin/python3 /usr/bin/python
+ENV PATH=/google-cloud-sdk/bin:$PATH
+RUN groupadd -r -g 1000 cloudsdk && \
+    useradd -r -u 1000 -m -s /bin/bash -g cloudsdk cloudsdk
+
+RUN apt-get update -qqy && apt-get install -qqy \
+        curl \
+        apt-transport-https \
+        lsb-release \
+        openssh-client \
+        git \
+        make \
+        gnupg \
+        openjdk-21-jre-headless && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN cp /google-cloud-sdk/arch /tmp/arch
+
 RUN git config --system credential.'https://source.developers.google.com'.helper gcloud.sh
 VOLUME ["/root/.config", "/root/.kube"]
+RUN gcloud config set metrics/environment docker_image_all_components
 
 FROM prod AS test
 ARG INSTALL_COMPONENTS_TEST=false
@@ -52,3 +88,4 @@ RUN if [ "$INSTALL_COMPONENTS_TEST" = "true" ]; then \
     fi
 
 FROM ${FINAL_STAGE}
+

--- a/debian_component_based/Dockerfile
+++ b/debian_component_based/Dockerfile
@@ -1,4 +1,14 @@
-FROM debian:trixie-slim
+ARG TARGETARCH=amd64
+FROM debian:trixie-slim AS base-amd64
+ENV CLOUDSDK_PYTHON=/google-cloud-sdk/platform/bundledpythonunix/bin/python3
+
+FROM debian:trixie-slim AS base-arm64
+RUN apt-get update -qqy && apt-get -qqy upgrade && apt-get install -qqy \
+        python3 \
+        python3-crcmod && \
+    rm -rf /var/lib/apt/lists/*
+
+FROM debian:trixie-slim AS build_image
 ARG CLOUD_SDK_VERSION
 ENV CLOUD_SDK_VERSION=$CLOUD_SDK_VERSION
 ENV PATH=/google-cloud-sdk/bin:$PATH
@@ -25,6 +35,30 @@ RUN echo -n "app-engine-java app-engine-python alpha beta pubsub-emulator cloud-
 RUN if [ `uname -m` = 'x86_64' ]; then echo -n " nomos anthos-auth" >> /tmp/additional_components; fi;
 RUN /google-cloud-sdk/install.sh --bash-completion=false --path-update=true --usage-reporting=false \
 	--additional-components `cat /tmp/additional_components` && rm -rf /google-cloud-sdk/.install/.backup
+
+ARG TARGETARCH
+FROM base-${TARGETARCH} AS runtime_image
+ARG TARGETARCH
+COPY --from=build_image /google-cloud-sdk /google-cloud-sdk
+RUN if [ "$TARGETARCH" = "amd64" ]; then \
+        ln -sf /google-cloud-sdk/platform/bundledpythonunix/bin/python3 /usr/bin/python3; \
+    fi && \
+    ln -sf /usr/bin/python3 /usr/bin/python
+ENV PATH=/google-cloud-sdk/bin:$PATH
+RUN groupadd -r -g 1000 cloudsdk && \
+    useradd -r -u 1000 -m -s /bin/bash -g cloudsdk cloudsdk
+
+RUN apt-get update -qqy && apt-get install -qqy \
+        curl \
+        apt-transport-https \
+        lsb-release \
+        openssh-client \
+        git \
+        gnupg \
+        openjdk-21-jre-headless && \
+    rm -rf /var/lib/apt/lists/*
+
 RUN git config --system credential.'https://source.developers.google.com'.helper gcloud.sh
 VOLUME ["/root/.config", "/root/.kube"]
 RUN gcloud config set metrics/environment docker_image_debian_component_based
+

--- a/debian_slim/Dockerfile
+++ b/debian_slim/Dockerfile
@@ -1,4 +1,14 @@
-FROM debian:trixie-slim
+ARG TARGETARCH=amd64
+FROM debian:trixie-slim AS base-amd64
+ENV CLOUDSDK_PYTHON=/usr/lib/google-cloud-sdk/platform/bundledpythonunix/bin/python3
+
+FROM debian:trixie-slim AS base-arm64
+RUN apt-get update -qqy && apt-get -qqy upgrade && apt-get install -qqy \
+        python3 \
+        python3-crcmod && \
+    rm -rf /var/lib/apt/lists/*
+
+FROM debian:trixie-slim AS build_image
 ARG CLOUD_SDK_VERSION
 ENV CLOUD_SDK_VERSION=$CLOUD_SDK_VERSION
 RUN groupadd -r -g 1000 cloudsdk && \
@@ -21,12 +31,39 @@ RUN apt-get update -qqy && apt-get -qqy upgrade && apt-get install -qqy \
         > /etc/apt/sources.list.d/google-cloud-sdk.list && \
     curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg  | gpg --dearmor -o /etc/apt/keyrings/google-cloud-cli.gpg && \
     apt-get update && apt-get install -y google-cloud-cli=${CLOUD_SDK_VERSION}-0 $INSTALL_COMPONENTS && \
-    gcloud config set core/disable_usage_reporting true && \
+    rm -rf /root/.cache/pip/ && \
+    find /usr/lib/google-cloud-sdk -name '*.pyc' -delete && \
+    find /usr/lib/google-cloud-sdk -name '*__pycache__*' -delete
+
+ARG TARGETARCH
+FROM base-${TARGETARCH} AS runtime_image
+ARG TARGETARCH
+COPY --from=build_image /usr/lib/google-cloud-sdk /usr/lib/google-cloud-sdk
+RUN if [ "$TARGETARCH" = "amd64" ]; then \
+        ln -sf /usr/lib/google-cloud-sdk/platform/bundledpythonunix/bin/python3 /usr/bin/python3; \
+    fi && \
+    ln -sf /usr/bin/python3 /usr/bin/python
+
+ENV PATH=$PATH:/usr/lib/google-cloud-sdk/bin
+RUN groupadd -r -g 1000 cloudsdk && \
+    useradd -r -u 1000 -m -s /bin/bash -g cloudsdk cloudsdk
+
+RUN apt-get update -qqy && apt-get install -qqy \
+        curl \
+        apt-transport-https \
+        lsb-release \
+        openssh-client \
+        git \
+        gnupg && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN gcloud config set core/disable_usage_reporting true && \
     gcloud config set component_manager/disable_update_check true && \
     gcloud config set metrics/environment docker_image_slim && \
     gcloud --version && \
     gsutil version -l && \
     bq version && \
-    gcloud-crc32c /usr/bin/gcloud
+    gcloud-crc32c /usr/lib/google-cloud-sdk/bin/gcloud
 RUN git config --system credential.'https://source.developers.google.com'.helper gcloud.sh
 VOLUME ["/root/.config"]
+

--- a/stable/Dockerfile
+++ b/stable/Dockerfile
@@ -1,3 +1,13 @@
+ARG TARGETARCH=amd64
+FROM debian:trixie-slim AS base-amd64
+ENV CLOUDSDK_PYTHON=/usr/lib/google-cloud-sdk/platform/bundledpythonunix/bin/python3
+
+FROM debian:trixie-slim AS base-arm64
+RUN apt-get update -qqy && apt-get -qqy upgrade && apt-get install -qqy \
+        python3-dev \
+        python3-crcmod && \
+    rm -rf /var/lib/apt/lists/*
+
 FROM debian:trixie-slim AS build_image
 
 ARG CLOUD_SDK_VERSION
@@ -19,17 +29,21 @@ RUN apt-get update -qqy && apt-get -qqy upgrade && \
     rm -rf /root/.cache/pip/ && \
     find /usr/lib/google-cloud-sdk -name '*.pyc' -delete && \
     find /usr/lib/google-cloud-sdk -name '*__pycache__*' -delete
-FROM debian:trixie-slim AS runtime_image
+
+ARG TARGETARCH
+FROM base-${TARGETARCH} AS runtime_image
+ARG TARGETARCH
 COPY --from=build_image /usr/lib/google-cloud-sdk /usr/lib/google-cloud-sdk
+RUN if [ "$TARGETARCH" = "amd64" ]; then \
+        ln -sf /usr/lib/google-cloud-sdk/platform/bundledpythonunix/bin/python3 /usr/bin/python3; \
+    fi && \
+    ln -sf /usr/bin/python3 /usr/bin/python
 
 ENV PATH=$PATH:/usr/lib/google-cloud-sdk/bin
 # Create a non-root user
 RUN groupadd -r -g 1000 cloudsdk && \
     useradd -r -u 1000 -m -s /bin/bash -g cloudsdk cloudsdk
-RUN if [ `uname -m` = 'x86_64' ]; then echo -n "x86_64" > /tmp/arch; else echo -n "arm" > /tmp/arch && \
-    apt-get update -qqy && apt-get -qqy upgrade && apt-get install -qqy \
-        python3-dev \
-        python3-crcmod; fi;
+RUN if [ "$TARGETARCH" = "amd64" ]; then echo -n "x86_64" > /tmp/arch; else echo -n "arm" > /tmp/arch; fi;
 RUN gcloud --version && \
     gsutil version -l && \
     bq version && \
@@ -46,3 +60,4 @@ COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 
 # Set the entrypoint to the preprocessing script
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+


### PR DESCRIPTION
We clean up the system python3 installation in the final runtime stage for amd64, since it needs system python for install but amd64 should use bundled python after install. On arm64, we keep system python since there is no bundled python.